### PR TITLE
fix: Set config.port to match web-app's exposed port

### DIFF
--- a/charms/kserve-web-app/config.yaml
+++ b/charms/kserve-web-app/config.yaml
@@ -3,5 +3,5 @@
 options:
   port:
     type: int
-    default: 80
+    default: 5000
     description: Listening port


### PR DESCRIPTION
This fixes the kserve-model-web-app by using the correct port (5000) for the web application.  As far as I can tell, this is not configurable at the application level, so probably config.port can be removed entirely. 

To test:
```
charmcraft pack
juju deploy ./kserve-web-app_ubuntu-20.04-amd64.charm --resource kserve-web-app-image=kserve/models-web-app:v0.8.0
juju deploy istio-pilot --trust --channel 1.11/stable --config default-gateway=my-gateway
juju deploy istio-gateway istio-ingressgateway --trust --channel 1.11/stable --config kind=ingress
juju relate istio-pilot istio-ingressgateway
```

Now you should be able to browse to the following:
* unitIP:5000
* serviceIP:5000
But for some reason (not sure why?  something to do with the way the app is coded maybe?) those will show as blank screens (but the title does show, so you know you've hit the application)

If we add the ingress relation to get access through our istio ingress:
```
juju relate istio-pilot:ingress kserve-web-app:ingress
```

We can see:
* `kubectl get vs -A` should show one for kserve
* browsing to ingressIP/kserve-endpoints/ should show the full web UI (not just a blank page)