### PR TITLE
ci: enable lint, unit and integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
           
   lint:
     name: Lint Code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         charm: [controller, web-app]
@@ -36,7 +36,7 @@ jobs:
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         charm: [controller, web-app]
@@ -47,7 +47,7 @@ jobs:
 
   charm-integration:
     name: Individual Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         charm: [controller, web-app]

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # TODO: add web-app once changes in canonical/kserve-operators#2 and #3
+        # are merged. Not running web-app lint tests as the charm is still WIP.
         charm: [controller, web-app]
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        charm: [controller, web-app]
+        # TODO: add web-app once changes in canonical/kserve-operators#2 and #3
+        # are merged. Not running web-app lint tests as the charm is still WIP.
+        charm: [controller]
     steps:
     - uses: actions/checkout@v3
     - run: sudo apt update && sudo apt install tox
@@ -50,7 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        charm: [controller, web-app]
+        # TODO: add web-app once changes in canonical/kserve-operators#2 and #3
+        # are merged. Not running web-app individual integration tests as
+        # the charm is still WIP.
+        charm: [controller]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -59,7 +66,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.24/stable
+          channel: 1.25/stable
           charmcraft-channel: latest/candidate
       - run: tox -e ${{ matrix.charm }}-integration
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check libs
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        charm: [kserve-web-app]
+        charm: [controller, web-app]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt update && sudo apt install tox
     - run: tox -e ${{ matrix.charm }}-lint
 
@@ -39,31 +39,29 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        charm: [kserve-web-app]
+        charm: [controller, web-app]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt update && sudo apt install tox
     - run: tox -e ${{ matrix.charm }}-unit
 
-  integration:
-    name: Integration Test
+  charm-integration:
+    name: Individual Integration Tests
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        charm: [kserve-web-app]
+        charm: [controller, web-app]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.21/stable
+          channel: 1.24/stable
           charmcraft-channel: latest/candidate
-
-      - name: Build and test
-        working-directory: ./charms/${{ matrix.charm }}
-        run: |
-          sg microk8s -c "tox -vve integration -- --model testing"
+      - run: tox -e ${{ matrix.charm }}-integration
 
       # On failure, capture debugging resources
       - name: Get all
@@ -84,8 +82,4 @@ jobs:
 
       - name: Get application logs
         run: kubectl logs -n testing --tail 1000 -ljuju-app=${{ matrix.charm }}
-        if: failure()
-
-      - name: Get argo-controller operator logs
-        run: kubectl logs -n testing --tail 1000 -ljuju-operator=${{ matrix.charm }}
         if: failure()

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -11,7 +11,7 @@ jobs:
 
   tests:
     name: Run Tests
-    uses: ./.github/workflows/integration.yaml
+    uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
 

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -18,7 +18,7 @@ jobs:
 
   tests:
     name: Run Tests
-    uses: ./.github/workflows/integration.yaml
+    uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,70 @@
+[flake8]
+max-line-length = 100
+
+[tox]
+skipsdist = True
+envlist = {controller,web-app}-{unit,lint,integration},integration
+
+[vars]
+all_path = {[vars]src_path} {[vars]tst_path}
+src_path = {toxinidir}/src/
+tst_path = {toxinidir}/tests/
+
+[testenv]
+allowlist_externals =
+  tox
+setenv =
+  controller: CHARM = controller
+  web-app: CHARM = web-app
+  unit: TYPE = unit
+  lint: TYPE = lint
+  integration: TYPE = integration
+commands =
+  tox -c charms/kserve-{env:CHARM} -e {env:TYPE}
+
+[testenv:update-requirements]
+allowlist_externals =
+    bash
+    find
+    pip-compile
+    xargs
+commands = 
+; uses 'bash -c' because piping didn't work in regular tox commands
+  pip-compile requirements-fmt.in
+  bash -c 'find . -type f -name "requirements*.in" | xargs --replace=\{\} pip-compile --resolver=backtracking \{\}'
+deps =
+    pip-tools
+description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
+
+[testenv:fmt]
+commands =
+    isort {[vars]tst_path}
+    black {[vars]tst_path}
+deps =
+    -r requirements-fmt.txt
+description = Apply coding style standards to code
+
+[testenv:lint]
+commands =
+    # uncomment the following line if this charm owns a lib
+    # codespell {[vars]lib_path}
+    codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
+      --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv \
+      --skip {toxinidir}/./.mypy_cache --skip {toxinidir}/./charms \
+      --skip {toxinidir}/./icon.svg --skip *.json.tmpl
+    # pflake8 wrapper supports config from pyproject.toml
+    pflake8 {[vars]tst_path}
+    isort --check-only --diff {[vars]tst_path}
+    black --check --diff {[vars]tst_path}
+deps =
+    -r requirements-lint.txt
+description = Check code against coding style standards
+
+[testenv:integration]
+whitelist_externals = tox
+passenv =
+  HOME
+  DISPLAY
+deps =
+  -r requirements-integration.txt
+commands = pytest -vvs --tb native --show-capture=no --log-cli-level=INFO --asyncio-mode=auto {posargs} {toxinidir}/charms/kserve-{env:CHARM}


### PR DESCRIPTION
In this PR:
* tox.ini is added defining how to run lint, unit, and integration tests. Regarding the latter, only the individual charm's integration tests will be run as integration between web-app and controller hasn't been added.

* Integration job inside on pull/push yaml files is renamed to `integrate.yaml`