### PR TITLE
tests: add set_can_connect to harness for testing pebble related objects

### DIFF
--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -52,6 +52,8 @@ def harness():
     """Returns a harnessed charm with leader == True."""
     harness = Harness(KServeControllerCharm)
     harness.set_leader(True)
+    harness.set_can_connect("kserve-controller", True)
+    harness.set_can_connect("kube-rbac-proxy", True)
     return harness
 
 


### PR DESCRIPTION
We need to set_can_connect in order to access containers and pebble related objects. Prevents the following from happening:

```
ops.pebble.ConnectionError: Cannot connect to Pebble; did you forget to call begin_with_initial_hooks() or set_can_connect()?
```