### PR TITLE
ci: add reusable publish job

### DIFF
--- a/.github/workflows/get-charm-paths.sh
+++ b/.github/workflows/get-charm-paths.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+# Finds the charms in this repo, outputting them as JSON
+# Will return one of:
+# * the relative paths of the directories listed in `./charms`, if that directory exists
+# * "./", if the root directory has a "metadata.yaml" file
+# * otherwise, error
+#
+# Modified from: https://stackoverflow.com/questions/63517732/github-actions-build-matrix-for-lambda-functions/63736071#63736071
+CHARMS_DIR="./charms"
+if [ -d "$CHARMS_DIR" ];
+then
+  CHARM_PATHS=$(find $CHARMS_DIR -maxdepth 1 -type d -not -path '*/\.*' -not -path "$CHARMS_DIR")
+else
+  if [ -f "./metadata.yaml" ]
+  then
+    CHARM_PATHS="./"
+  else
+    echo "Cannot find valid charm directories - aborting"
+    exit 1
+  fi
+fi
+
+# Convert output to JSON string format
+# { charm_paths: [...] }
+CHARM_PATHS_LIST=$(echo "$CHARM_PATHS" | jq -c --slurp --raw-input 'split("\n")[:-1]')
+
+echo "Found CHARM_PATHS_LIST: $CHARM_PATHS_LIST"
+
+echo "::set-output name=CHARM_PATHS_LIST::$CHARM_PATHS_LIST"

--- a/.github/workflows/get-charm-paths.sh
+++ b/.github/workflows/get-charm-paths.sh
@@ -23,8 +23,11 @@ fi
 
 # Convert output to JSON string format
 # { charm_paths: [...] }
+
 CHARM_PATHS_LIST=$(echo "$CHARM_PATHS" | jq -c --slurp --raw-input 'split("\n")[:-1]')
 
-echo "Found CHARM_PATHS_LIST: $CHARM_PATHS_LIST"
+# FIXME: kserve-web-app is not ready to be built and published, the publish job for
+# that charm is expected to fail. It can be ignored until the charm is not WIP.
+echo "Found CHARM_PATHS_LIST: $CHARM_PATHS_LIST (Only publishing kserve-controller)"
 
 echo "::set-output name=CHARM_PATHS_LIST::$CHARM_PATHS_LIST"

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,4 +1,4 @@
-name: Test and publish to branch
+name: On Pull Request
 
 # On pull_request, we:
 # * always publish to charmhub at latest/edge/branchname
@@ -13,11 +13,11 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
     secrets:
-      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
     secrets:
-      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,35 +1,93 @@
-# reusable workflow triggered by other actions
+# reusable workflow for publishing all charms in this repo
 name: Publish
 
 on:
   workflow_call:
+    inputs:
+      source_branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        default: ''
+        required: false
+        type: string
     secrets:
-      charmcraft-credentials:
+      CHARMCRAFT_CREDENTIALS:
         required: true
+  workflow_dispatch:
+    inputs:
+      destination_channel:
+        description: CharmHub channel to publish to
+        required: false
+        default: 'latest/edge'
+        type: string
+      source_branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        required: false
+        default: ''
+        type: string
 
 jobs:
+  get-charm-paths:
+    name: Generate the Charm Matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
+    steps:
+      - uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+          ref: ${{ inputs.source_branch }}
+      - name: Get paths for all charms in repo
+        id: get-charm-paths
+        run: bash .github/workflows/get-charm-paths.sh
+
 
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-20.04
+    needs: get-charm-paths
     strategy:
       fail-fast: false
       matrix:
-        charm:
-          - kserve-web-app
+        charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ inputs.source_branch }}
+
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.1
-        id: channel
+        uses: canonical/charming-actions/channel@2.2.2
+        id: select-channel
+        if: ${{ inputs.destination_channel == '' }}
+
+      # Combine inputs from different sources to a single canonical value so later steps don't
+      # need logic for picking the right one
+      - name: Parse and combine inputs
+        id: parse-inputs
+        run: |
+          # destination_channel
+          destination_channel="${{ inputs.destination_channel || steps.select-channel.outputs.name }}"
+          echo "setting output of destination_channel=$destination_channel"
+          echo "::set-output name=destination_channel::$destination_channel"
+
+          # tag_prefix
+          # if charm_path = ./ --> tag_prefix = '' (null)
+          # if charm_path != ./some-charm (eg: a charm in a ./charms dir) --> tag_prefix = 'some-charm'
+          if [ ${{ matrix.charm-path }} == './' ]; then
+            tag_prefix=''
+          else
+            tag_prefix=$(basename ${{ matrix.charm-path }} )
+          fi
+          echo "setting output of tag_prefix=$tag_prefix"
+          echo "::set-output name=tag_prefix::$tag_prefix"
+
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.2.2
         with:
-          credentials: ${{ secrets.charmcraft-credentials }}
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          charm-path: charms/${{ matrix.charm }}
-          channel: ${{ steps.channel.outputs.name }}
-          tag-prefix: ${{ matrix.charm }}
+          charm-path: ${{ matrix.charm-path }}
+          channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+          tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}


### PR DESCRIPTION
This publish job replaces the older one with the standard reusable publish job in all Charmed Kubeflow repositories.

Dear reviewer: the publish job for kserve-web-app is expected to fail as the charm is not ready yet. We can safely ignore it.