### PR TITLE
feat: unpin juju agent-version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -67,8 +67,6 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25/stable
-          # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
-          bootstrap-options: "--agent-version=2.9.34"
           charmcraft-channel: latest/candidate
       - run: tox -e ${{ matrix.charm }}-integration
 


### PR DESCRIPTION
Unpin juju agent-version (previously pinned to 2.9.34 by #51) because [the bug causing this](https://bugs.launchpad.net/juju/+bug/1992833) has been resolved