### PR TITLE
feat: refactor certs generation and add tests

### DIFF
--- a/charms/kserve-controller/src/templates/ssl.conf.j2
+++ b/charms/kserve-controller/src/templates/ssl.conf.j2
@@ -1,0 +1,33 @@
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+[ dn ]
+C = GB
+ST = Canonical
+L = Canonical
+O = Canonical
+OU = Canonical
+CN = 127.0.0.1
+[ req_ext ]
+subjectAltName = @alt_names
+[ alt_names ]
+DNS.1 = {{ service_name }}
+DNS.2 = {{ service_name }}.{{ namespace }}
+DNS.3 = {{ service_name }}.{{ namespace }}.svc
+DNS.4 = {{ service_name }}.{{ namespace }}.svc.cluster
+DNS.5 = {{ service_name }}.{{ namespace }}.svc.cluster.local
+DNS.6 = {{ webhook_server_service }}
+DNS.7 = {{ webhook_server_service }}.{{ namespace }}
+DNS.8 = {{ webhook_server_service }}.{{ namespace }}.svc
+DNS.9 = {{ webhook_server_service }}.{{ namespace }}.svc.cluster
+DNS.10 = {{ webhook_server_service }}.{{ namespace }}.svc.cluster.local
+IP.1 = 127.0.0.1
+[ v3_ext ]
+authorityKeyIdentifier=keyid,issuer:always
+basicConstraints=CA:FALSE
+keyUsage=keyEncipherment,dataEncipherment,digitalSignature
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=@alt_names

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -76,9 +76,9 @@ def mocked_lightkube_client(mocker, mocked_resource_handler):
 @pytest.fixture()
 def mocked_gen_certs(mocker):
     """Yields a mocked gen_certs."""
-    yield mocker.patch("charm.KServeControllerCharm.gen_certs")
+    yield mocker.patch("charm.KServeControllerCharm._gen_certs")
 
-
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_events(harness, mocked_resource_handler, mocker):
     harness.begin()
     on_install = mocker.patch("charm.KServeControllerCharm._on_install")
@@ -103,6 +103,7 @@ def test_events(harness, mocked_resource_handler, mocker):
     on_kube_rbac_proxy_ready.assert_called_once()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_install_active(harness, mocked_resource_handler):
     harness.begin()
     harness.charm._k8s_resource_handler = mocked_resource_handler
@@ -112,6 +113,7 @@ def test_on_install_active(harness, mocked_resource_handler):
     assert harness.charm.model.unit.status == ActiveStatus()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_install_exception(harness, mocked_resource_handler, mocker):
     mocked_logger = mocker.patch("charm.log")
     harness.begin()
@@ -123,6 +125,7 @@ def test_on_install_exception(harness, mocked_resource_handler, mocker):
     mocked_logger.error.assert_called()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_kube_rbac_proxy_ready_active(harness, mocker):
     harness.begin()
 
@@ -143,6 +146,7 @@ def test_on_kube_rbac_proxy_ready_active(harness, mocker):
     assert harness.model.unit.status == ActiveStatus()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_kube_rbac_proxy_ready_exception_blocked(harness, mocker):
     harness.begin()
 
@@ -155,6 +159,7 @@ def test_on_kube_rbac_proxy_ready_exception_blocked(harness, mocker):
     mocked_logger.info.assert_not_called()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_kube_rbac_proxy_ready_exception_other(harness, mocker):
     harness.begin()
 
@@ -168,6 +173,7 @@ def test_on_kube_rbac_proxy_ready_exception_other(harness, mocker):
     mocked_logger.error.assert_not_called()
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_on_kserve_controller_ready_active(harness, mocker):
     harness.begin()
 
@@ -181,7 +187,8 @@ def test_on_kserve_controller_ready_active(harness, mocker):
     # assert harness.get_container_pebble_plan("kserve-controller")._services != {}
 
 
-def test_on_remove_success(harness, mocker, mocked_resource_handler, mocked_gen_certs):
+@pytest.mark.usefixtures('mocked_gen_certs')
+def test_on_remove_success(harness, mocker, mocked_resource_handler):
     mocked_delete_many = mocker.patch("charm.delete_many")
     harness.begin()
     harness.charm._k8s_resource_handler = mocked_resource_handler
@@ -191,7 +198,8 @@ def test_on_remove_success(harness, mocker, mocked_resource_handler, mocked_gen_
     assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
 
 
-def test_on_remove_failure(harness, mocker, mocked_resource_handler, mocked_gen_certs):
+@pytest.mark.usefixtures('mocked_gen_certs')
+def test_on_remove_failure(harness, mocker, mocked_resource_handler):
     harness.begin()
 
     mocked_delete_many = mocker.patch("charm.delete_many")
@@ -205,9 +213,9 @@ def test_on_remove_failure(harness, mocker, mocked_resource_handler, mocked_gen_
         harness.charm.on.remove.emit()
     mocked_logger.warning.assert_called()
 
-
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_generate_gateways_context_raw_mode_no_relation(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness, mocker, mocked_resource_handler
 ):
     """Assert the unit gets blocked if no relation."""
     harness.set_model_name("test-model")
@@ -219,8 +227,9 @@ def test_generate_gateways_context_raw_mode_no_relation(
     )
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_generate_gateways_context_serverless_no_relation(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness, mocker, mocked_resource_handler
 ):
     """Assert the unit gets blocked if no relation."""
     harness.set_model_name("test-model")
@@ -244,11 +253,12 @@ def test_generate_gateways_context_serverless_no_relation(
     )
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 @pytest.mark.parametrize(
     "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
 )
 def test_generate_gateways_context_raw_mode_missing_data(
-    remote_data, harness, mocker, mocked_resource_handler, mocked_gen_certs
+    remote_data, harness, mocker, mocked_resource_handler
 ):
     """Assert the unit goes to waiting status if there is incomplete data."""
     harness.set_model_name("test-model")
@@ -265,11 +275,12 @@ def test_generate_gateways_context_raw_mode_missing_data(
     assert harness.charm.model.unit.status == WaitingStatus("Waiting for ingress gateway data.")
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 @pytest.mark.parametrize(
     "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
 )
 def test_generate_gateways_context_serverless_missing_data(
-    remote_data, harness, mocker, mocked_resource_handler, mocked_gen_certs
+    remote_data, harness, mocker, mocked_resource_handler
 ):
     """Assert the unit goes to waiting status if there is incomplete data."""
     harness.set_model_name("test-model")
@@ -297,8 +308,9 @@ def test_generate_gateways_context_serverless_missing_data(
     assert harness.charm.model.unit.status == WaitingStatus("Waiting for local gateway data.")
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_generate_gateways_context_raw_mode_pass(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness, mocker, mocked_resource_handler
 ):
     """Assert the gateway context is correct."""
     harness.set_model_name("test-model")
@@ -335,8 +347,9 @@ def test_generate_gateways_context_raw_mode_pass(
     assert actual_gateway_context == expected_gateway_context
 
 
+@pytest.mark.usefixtures('mocked_gen_certs')
 def test_generate_gateways_context_serverless_mode_pass(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness, mocker, mocked_resource_handler
 ):
     """Assert the gateway context is correct."""
     harness.set_model_name("test-model")

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -18,7 +18,7 @@ RBAC_PROXY_EXPECTED_LAYER = {
         "kube-rbac-proxy": {
             "override": "replace",
             "summary": "Kube Rbac Proxy",
-            "command": "/usr/local/bin/kube-rbac-proxy --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:8080 --logtostderr=true --v=10",
+            "command": "/usr/local/bin/kube-rbac-proxy --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:8080 --logtostderr=true --v=10",  # noqa E501
             "startup": "enabled",
         }
     }
@@ -77,6 +77,7 @@ def mocked_lightkube_client(mocker, mocked_resource_handler):
 def mocked_gen_certs(mocker):
     """Yields a mocked gen_certs."""
     yield mocker.patch("charm.KServeControllerCharm._gen_certs")
+
 
 @pytest.mark.usefixtures('mocked_gen_certs')
 def test_events(harness, mocked_resource_handler, mocker):
@@ -213,10 +214,9 @@ def test_on_remove_failure(harness, mocker, mocked_resource_handler):
         harness.charm.on.remove.emit()
     mocked_logger.warning.assert_called()
 
+
 @pytest.mark.usefixtures('mocked_gen_certs')
-def test_generate_gateways_context_raw_mode_no_relation(
-    harness, mocker, mocked_resource_handler
-):
+def test_generate_gateways_context_raw_mode_no_relation(harness, mocker, mocked_resource_handler):
     """Assert the unit gets blocked if no relation."""
     harness.set_model_name("test-model")
     harness.begin()
@@ -309,9 +309,7 @@ def test_generate_gateways_context_serverless_missing_data(
 
 
 @pytest.mark.usefixtures('mocked_gen_certs')
-def test_generate_gateways_context_raw_mode_pass(
-    harness, mocker, mocked_resource_handler
-):
+def test_generate_gateways_context_raw_mode_pass(harness, mocker, mocked_resource_handler):
     """Assert the gateway context is correct."""
     harness.set_model_name("test-model")
     harness.begin()
@@ -348,9 +346,7 @@ def test_generate_gateways_context_raw_mode_pass(
 
 
 @pytest.mark.usefixtures('mocked_gen_certs')
-def test_generate_gateways_context_serverless_mode_pass(
-    harness, mocker, mocked_resource_handler
-):
+def test_generate_gateways_context_serverless_mode_pass(harness, mocker, mocked_resource_handler):
     """Assert the gateway context is correct."""
     harness.set_model_name("test-model")
     harness.begin()
@@ -396,3 +392,17 @@ def test_generate_gateways_context_serverless_mode_pass(
         "local_gateway_service_name": "knative-local-gateway",
     }
     assert actual_gateway_context == expected_gateway_context
+
+
+def test_get_certs(harness, mocker, mocked_resource_handler):
+    """Test certs generation."""
+    harness.set_model_name("test-model")
+    harness.begin()
+    harness.charm._k8s_resource_handler = mocked_resource_handler
+
+    # obtain certs and verify contents
+    cert_info = harness.charm._gen_certs()
+    assert cert_info is not None
+    assert len(cert_info) == 3
+    for cert in cert_info.items():
+        assert len(str(cert[1])) != 0


### PR DESCRIPTION
# Summary:
- use clean implementation for generating certs
- add unit tests to check on certs generation and its contents