### PR TITLE
fix: restart kserve-controller service on config changed

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -75,6 +75,14 @@ jobs:
         run: kubectl get all -A
         if: failure()
 
+      - name: Get inference servers
+        run: kubectl get inferenceservices -A
+        if: failure()
+
+      - name: Get events
+        run: kubectl get events -A
+        if: failure()
+
       - name: Describe deployments
         run: kubectl describe deployments -A
         if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,9 +63,10 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.25/stable
+          channel: 1.24/stable
           # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
           bootstrap-options: "--agent-version=2.9.34"
+          microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
       - run: tox -e ${{ matrix.charm }}-integration
 

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -269,12 +269,7 @@ class KServeControllerCharm(CharmBase):
         # The kserve-controller service must be restarted whenever the
         # configuration is changed, otherwise the service will remain
         # unaware of the changes.
-        try:
-            self.controller_container.restart(self._controller_container_name)
-        except APIError as err:
-            raise GenericCharmRuntimeError(
-                f"Failed to restart {self._controller_container_name} service"
-            ) from err
+        self._restart_controller_service()
 
     def _on_remove(self, _):
         self.unit.status = MaintenanceStatus("Removing k8s resources")
@@ -471,6 +466,15 @@ subjectAltName=@alt_names"""
                 "/run/ssl.conf",
             ]
         )
+
+    def _restart_controller_service(self) -> None:
+        """Restart the kserve-controller service."""
+        try:
+            self.controller_container.restart(self._controller_container_name)
+        except APIError as err:
+            raise GenericCharmRuntimeError(
+                f"Failed to restart {self._controller_container_name} service"
+            ) from err
 
 
 if __name__ == "__main__":

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -29,7 +29,13 @@ from charms.istio_pilot.v0.istio_gateway_info import (
 from lightkube import ApiError
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    ModelError,
+    WaitingStatus,
+)
 from ops.pebble import APIError, Layer
 
 # from lightkube_custom_resources.serving import ClusterServingRuntime_v1alpha1

--- a/charms/kserve-controller/tests/integration/sklearn-iris.yaml
+++ b/charms/kserve-controller/tests/integration/sklearn-iris.yaml
@@ -1,7 +1,7 @@
 apiVersion: "serving.kserve.io/v1beta1"
 kind: "InferenceService"
 metadata:
-  generateName: "sklearn-iris-"
+  name: "sklearn-iris"
 spec:
   predictor:
     model:

--- a/charms/kserve-controller/tests/integration/sklearn-iris.yaml
+++ b/charms/kserve-controller/tests/integration/sklearn-iris.yaml
@@ -1,7 +1,7 @@
 apiVersion: "serving.kserve.io/v1beta1"
 kind: "InferenceService"
 metadata:
-  name: "sklearn-iris"
+  generateName: "sklearn-iris-"
 spec:
   predictor:
     model:

--- a/charms/kserve-controller/tests/integration/sklearn-iris.yaml
+++ b/charms/kserve-controller/tests/integration/sklearn-iris.yaml
@@ -8,3 +8,10 @@ spec:
       modelFormat:
         name: sklearn
       storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
+      resources:
+        limits:
+          cpu: 1
+          memory: 500Mi
+        requests:
+          cpu: 100m
+          memory: 250Mi

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -109,7 +109,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     # Assert InferenceService state is Available
     @tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=1, max=15),
-        stop=tenacity.stop_after_attempt(10),
+        stop=tenacity.stop_after_attempt(30),
         reraise=True,
     )
     def assert_inf_svc_state():
@@ -210,7 +210,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     # Assert InferenceService state is Available
     @tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=1, max=15),
-        stop=tenacity.stop_after_attempt(10),
+        stop=tenacity.stop_after_attempt(30),
         reraise=True,
     )
     def assert_inf_svc_state():

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -94,7 +94,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     rawdeployment_mode_namespace = "raw_namespace"
 
     # Create RawDeployment namespace
-    lightkube.create(Namespace, name=rawdeployment_mode_namespace)
+    lightkube_client.create(Namespace, name=rawdeployment_mode_namespace)
 
     # Create InferenceService from example file
     @tenacity.retry(
@@ -195,7 +195,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     serverless_mode_namespace = "serverless_namespace"
 
     # Create Serverless namespace
-    lightkube.create(Namespace, name=serverless_mode_namespace)
+    lightkube_client.create(Namespace, name=serverless_mode_namespace)
 
     # Create InferenceService from example file
     @tenacity.retry(

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -92,7 +92,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     inf_svc_yaml = yaml.safe_load(Path("./tests/integration/sklearn-iris.yaml").read_text())
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
     inf_svc_name = inf_svc_object.metadata.name
-    rawdeployment_mode_namespace = "raw_namespace"
+    rawdeployment_mode_namespace = "raw-namespace"
 
     # Create RawDeployment namespace
     lightkube_client.create(Namespace(metadata=ObjectMeta(name=rawdeployment_mode_namespace)))
@@ -193,7 +193,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     inf_svc_yaml = yaml.safe_load(Path("./tests/integration/sklearn-iris.yaml").read_text())
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
     inf_svc_name = inf_svc_object.metadata.name
-    serverless_mode_namespace = "serverless_namespace"
+    serverless_mode_namespace = "serverless-namespace"
 
     # Create Serverless namespace
     lightkube_client.create(Namespace(metadata=ObjectMeta(name=serverless_mode_namespace)))

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -92,6 +92,8 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     )
     inf_svc_yaml = yaml.safe_load(Path("./tests/integration/sklearn-iris.yaml").read_text())
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
+    inf_svc_name = inf_svc_object.metadata.name
+    rawdeployment_mode_namespace = "raw_namespace"
 
     # Create InferenceService from example file
     @tenacity.retry(
@@ -100,7 +102,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
         reraise=True,
     )
     def create_inf_svc():
-        lightkube_client.create(inf_svc_object, namespace=namespace)
+        lightkube_client.create(inf_svc_object, namespace=rawdeployment_mode_namespace)
 
     # Assert InferenceService state is Available
     @tenacity.retry(
@@ -110,7 +112,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     )
     def assert_inf_svc_state():
         inf_svc = lightkube_client.get(
-            inference_service_resource, "sklearn-iris", namespace=namespace
+            inference_service_resource, inf_svc_name, namespace=rawdeployment_mode_namespace
         )
         conditions = inf_svc.get("status", {}).get("conditions")
         for condition in conditions:
@@ -124,7 +126,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     assert_inf_svc_state()
 
     # Remove the InferenceService deployed in RawDeployment mode
-    lightkube_client.delete(inference_service_resource, name="sklearn-iris", namespace=namespace)
+    lightkube_client.delete(inference_service_resource, name=inf_svc_name, namespace=rawdeployment_mode_namespace)
 
 
 async def test_deploy_knative_dependencies(ops_test: OpsTest):
@@ -189,6 +191,8 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     )
     inf_svc_yaml = yaml.safe_load(Path("./tests/integration/sklearn-iris.yaml").read_text())
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
+    inf_svc_name = inf_svc_object.metadata.name
+    serverless_mode_namespace = "serverless_namespace"
 
     # Create InferenceService from example file
     @tenacity.retry(
@@ -197,7 +201,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
         reraise=True,
     )
     def create_inf_svc():
-        lightkube_client.create(inf_svc_object, namespace=namespace)
+        lightkube_client.create(inf_svc_object, namespace=serverless_mode_namespace)
 
     # Assert InferenceService state is Available
     @tenacity.retry(
@@ -207,7 +211,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     )
     def assert_inf_svc_state():
         inf_svc = lightkube_client.get(
-            inference_service_resource, "sklearn-iris", namespace=namespace
+            inference_service_resource, inf_svc_name, namespace=serverless_mode_namespace
         )
         conditions = inf_svc.get("status", {}).get("conditions")
         for condition in conditions:

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -12,6 +12,7 @@ import lightkube.generic_resource
 import pytest
 import tenacity
 import yaml
+from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Namespace
 from pytest_operator.plugin import OpsTest
 
@@ -94,7 +95,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     rawdeployment_mode_namespace = "raw_namespace"
 
     # Create RawDeployment namespace
-    lightkube_client.create(Namespace, name=rawdeployment_mode_namespace)
+    lightkube_client.create(Namespace(metadata=ObjectMeta(name=rawdeployment_mode_namespace)))
 
     # Create InferenceService from example file
     @tenacity.retry(
@@ -195,7 +196,7 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     serverless_mode_namespace = "serverless_namespace"
 
     # Create Serverless namespace
-    lightkube_client.create(Namespace, name=serverless_mode_namespace)
+    lightkube_client.create(Namespace(metadata=ObjectMeta(name=serverless_mode_namespace)))
 
     # Create InferenceService from example file
     @tenacity.retry(

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -76,9 +76,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 def test_inference_service_raw_deployment(ops_test: OpsTest):
     """Validates that an InferenceService can be deployed."""
-    # Identify testing namespace (same as model)
-    namespace = ops_test.model_name
-
     # Instantiate a lightkube client
     lightkube_client = lightkube.Client()
 
@@ -126,7 +123,9 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     assert_inf_svc_state()
 
     # Remove the InferenceService deployed in RawDeployment mode
-    lightkube_client.delete(inference_service_resource, name=inf_svc_name, namespace=rawdeployment_mode_namespace)
+    lightkube_client.delete(
+        inference_service_resource, name=inf_svc_name, namespace=rawdeployment_mode_namespace
+    )
 
 
 async def test_deploy_knative_dependencies(ops_test: OpsTest):
@@ -175,9 +174,6 @@ async def test_deploy_knative_dependencies(ops_test: OpsTest):
 
 def test_inference_service_serverless_deployment(ops_test: OpsTest):
     """Validates that an InferenceService can be deployed."""
-    # Identify testing namespace (same as model)
-    namespace = ops_test.model_name
-
     # Instantiate a lightkube client
     lightkube_client = lightkube.Client()
 

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -12,6 +12,7 @@ import lightkube.generic_resource
 import pytest
 import tenacity
 import yaml
+from lightkube.core.exceptions import ApiError
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Namespace
 from pytest_operator.plugin import OpsTest
@@ -23,6 +24,18 @@ KNATIVE_VERSION = "latest/edge"
 ISTIO_INGRESS_GATEWAY = "test-gateway"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+
+
+@pytest.fixture
+def cleanup_namespaces_after_execution(request):
+    """Removes the namespaces used for deploying inferenceservices."""
+    yield
+    try:
+        lightkube_client = lightkube.Client()
+        lightkube_client.delete(Namespace, name=request.param)
+    except ApiError:
+        logger.warning(f"The {request.param} namespace could not be removed.")
+        pass
 
 
 @pytest.mark.abort_on_fail
@@ -76,7 +89,8 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
-def test_inference_service_raw_deployment(ops_test: OpsTest):
+@pytest.mark.parametrize("cleanup_namespaces_after_execution", ["raw-namespace"], indirect=True)
+def test_inference_service_raw_deployment(cleanup_namespaces_after_execution, ops_test: OpsTest):
     """Validates that an InferenceService can be deployed."""
     # Instantiate a lightkube client
     lightkube_client = lightkube.Client()
@@ -127,10 +141,11 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     create_inf_svc()
     assert_inf_svc_state()
 
-    # Remove the InferenceService deployed in RawDeployment mode
-    lightkube_client.delete(
-        inference_service_resource, name=inf_svc_name, namespace=rawdeployment_mode_namespace
-    )
+
+#    # Remove the InferenceService deployed in RawDeployment mode
+#    lightkube_client.delete(
+#        inference_service_resource, name=inf_svc_name, namespace=rawdeployment_mode_namespace
+#    )
 
 
 async def test_deploy_knative_dependencies(ops_test: OpsTest):
@@ -177,7 +192,12 @@ async def test_deploy_knative_dependencies(ops_test: OpsTest):
     )
 
 
-def test_inference_service_serverless_deployment(ops_test: OpsTest):
+@pytest.mark.parametrize(
+    "cleanup_namespaces_after_execution", ["serverless-namespace"], indirect=True
+)
+def test_inference_service_serverless_deployment(
+    cleanup_namespaces_after_execution, ops_test: OpsTest
+):
     """Validates that an InferenceService can be deployed."""
     # Instantiate a lightkube client
     lightkube_client = lightkube.Client()

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -12,6 +12,7 @@ import lightkube.generic_resource
 import pytest
 import tenacity
 import yaml
+from lightkube.resources.core_v1 import Namespace
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,9 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
     inf_svc_name = inf_svc_object.metadata.name
     rawdeployment_mode_namespace = "raw_namespace"
+
+    # Create RawDeployment namespace
+    lightkube.create(Namespace, name=rawdeployment_mode_namespace)
 
     # Create InferenceService from example file
     @tenacity.retry(
@@ -189,6 +193,9 @@ def test_inference_service_serverless_deployment(ops_test: OpsTest):
     inf_svc_object = lightkube.codecs.load_all_yaml(yaml.dump(inf_svc_yaml))[0]
     inf_svc_name = inf_svc_object.metadata.name
     serverless_mode_namespace = "serverless_namespace"
+
+    # Create Serverless namespace
+    lightkube.create(Namespace, name=serverless_mode_namespace)
 
     # Create InferenceService from example file
     @tenacity.retry(

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -123,7 +123,7 @@ def test_inference_service_raw_deployment(ops_test: OpsTest):
     create_inf_svc()
     assert_inf_svc_state()
 
-    # Remove the old InferenceService
+    # Remove the InferenceService deployed in RawDeployment mode
     lightkube_client.delete(inference_service_resource, name="sklearn-iris", namespace=namespace)
 
 

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -79,6 +79,12 @@ def mocked_gen_certs(mocker):
     yield mocker.patch("charm.KServeControllerCharm.gen_certs")
 
 
+@pytest.fixture()
+def mocked_restart_controller_service(mocker):
+    """Yields a mocked gen_certs."""
+    yield mocker.patch("charm.KServeControllerCharm._restart_controller_service")
+
+
 def test_events(harness, mocked_resource_handler, mocker):
     harness.begin()
     on_install = mocker.patch("charm.KServeControllerCharm._on_install")
@@ -220,7 +226,10 @@ def test_generate_gateways_context_raw_mode_no_relation(
 
 
 def test_generate_gateways_context_serverless_no_relation(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness,
+    mocker,
+    mocked_resource_handler,
+    mocked_restart_controller_service,
 ):
     """Assert the unit gets blocked if no relation."""
     harness.set_model_name("test-model")
@@ -248,7 +257,7 @@ def test_generate_gateways_context_serverless_no_relation(
     "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
 )
 def test_generate_gateways_context_raw_mode_missing_data(
-    remote_data, harness, mocker, mocked_resource_handler, mocked_gen_certs
+    remote_data, harness, mocker, mocked_resource_handler
 ):
     """Assert the unit goes to waiting status if there is incomplete data."""
     harness.set_model_name("test-model")
@@ -269,7 +278,12 @@ def test_generate_gateways_context_raw_mode_missing_data(
     "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
 )
 def test_generate_gateways_context_serverless_missing_data(
-    remote_data, harness, mocker, mocked_resource_handler, mocked_gen_certs
+    remote_data,
+    harness,
+    mocker,
+    mocked_resource_handler,
+    mocked_gen_certs,
+    mocked_restart_controller_service,
 ):
     """Assert the unit goes to waiting status if there is incomplete data."""
     harness.set_model_name("test-model")
@@ -336,7 +350,11 @@ def test_generate_gateways_context_raw_mode_pass(
 
 
 def test_generate_gateways_context_serverless_mode_pass(
-    harness, mocker, mocked_resource_handler, mocked_gen_certs
+    harness,
+    mocker,
+    mocked_resource_handler,
+    mocked_gen_certs,
+    mocked_restart_controller_service,
 ):
     """Assert the gateway context is correct."""
     harness.set_model_name("test-model")

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -5,6 +5,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import ops.testing
 import pytest
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from lightkube import ApiError
@@ -12,8 +13,6 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.testing import Harness
 
 from charm import KServeControllerCharm
-
-import ops.testing
 
 # enable simulation of container networking
 ops.testing.SIMULATE_CAN_CONNECT = True
@@ -404,6 +403,7 @@ def test_generate_gateways_context_serverless_mode_pass(
     }
     assert actual_gateway_context == expected_gateway_context
 
+
 @patch("charm.KServeControllerCharm.gen_certs")
 @patch("charm.KServeControllerCharm._push_controller_certificates")
 def test_restart_controller_service(_gen_certs, _push_controller_certificates, harness, mocker):
@@ -413,8 +413,12 @@ def test_restart_controller_service(_gen_certs, _push_controller_certificates, h
     # Before pebble ready, the service should not be
     # there, so no action should be taken
     harness.charm._restart_controller_service()
-    controller_pebble_plan = harness.get_container_pebble_plan(harness.charm._controller_container_name)
-    controller_service = controller_pebble_plan.services.get(harness.charm._controller_container_name)
+    controller_pebble_plan = harness.get_container_pebble_plan(
+        harness.charm._controller_container_name
+    )
+    controller_service = controller_pebble_plan.services.get(
+        harness.charm._controller_container_name
+    )
     assert controller_service is None
 
     # Simulate what happens after the pebble ready event


### PR DESCRIPTION
Restarting the service ensures it catches new configurations.

Dear reviewer(s), please note this PR also includes small fixes to the CI and integration tests to unblock them. If you think they belong in a different PR, let me know.

Fixes #103, #105