### PR TITLE
fix: add logic in config change event handler

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -271,12 +271,26 @@ class KServeControllerCharm(CharmBase):
         self.model.unit.status = ActiveStatus()
 
     def _on_config_changed(self, event):
-        self._on_install(event)
+        """Handle the config changed event."""
+        try:
+            self.unit.status = MaintenanceStatus("Applying changes to k8s resources")
+            self.cm_resource_handler.apply()
+        except ErrorWithStatus as err:
+            self.model.unit.status = err.status
+            log.error(f"Failed to handle {event} with error: {err}")
+            return
+        except ApiError as api_err:
+            log.error(api_err)
+            raise
 
         # The kserve-controller service must be restarted whenever the
         # configuration is changed, otherwise the service will remain
         # unaware of such changes.
         self._restart_controller_service()
+
+        # Set active status only after applying new configuration and
+        # restarting the kserve-controller service.
+        self.model.unit.status = ActiveStatus()
 
     def _on_remove(self, _):
         self.unit.status = MaintenanceStatus("Removing k8s resources")

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -121,6 +121,24 @@ def test_on_install_exception(harness, mocked_resource_handler, mocker):
     mocked_logger.error.assert_called()
 
 
+def test_on_config_active(harness, mocked_resource_handler):
+    harness.begin()
+    harness.charm._cm_resource_handler = mocked_resource_handler
+    harness.charm.on.config_changed.emit()
+    mocked_resource_handler.apply.assert_called()
+    assert harness.charm.model.unit.status == ActiveStatus()
+
+
+def test_on_config_exception(harness, mocked_resource_handler, mocker):
+    mocked_logger = mocker.patch("charm.log")
+    harness.begin()
+    mocked_resource_handler.apply.side_effect = _FakeApiError()
+    harness.charm._cm_resource_handler = mocked_resource_handler
+    with pytest.raises(ApiError):
+        harness.charm.on.install.emit()
+    mocked_logger.error.assert_called()
+
+
 def test_on_kube_rbac_proxy_ready_active(harness, mocker):
     harness.begin()
 


### PR DESCRIPTION
The config change event handler should manage configuration changes on its own to be able to correctly render and apply the inferenceservice-config ConfigMap. Also on this event handler, we are restarting the kserve-controller service, which should be restarted AFTER and only IFF the aforementioned ConfigMap is configured correctly, that is, after the configuration for the two deployment modes are set as expected.

The intention of this patch is to fix an incorrect behaviour where the order of events have a large effect on how the ConfigMap is rendered and when the kserve-controller service is restarted. For instance if kserve-controller's config is changed from RawDeployment to Serverless before the knative-serving relation was established, the charm code would've raised an expcetion and the kserve-controller charm would've went into BlockedStatus asking for this relation, also the ConfigMap wouldn't have been rendered with the information knative-serving provides and it would've stayed with the RawDeployment configuration.