### PR TITLE
feat: script to gather all workload images (DO NOT MERGE)

### DIFF
--- a/charms/kserve-controller/tox.ini
+++ b/charms/kserve-controller/tox.ini
@@ -40,7 +40,7 @@ commands =
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
-      --skip *.json.tmpl --skip *.j2
+      --skip *.json.tmpl --skip *.j2 --skip {toxinidir}/./lib
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -8,6 +8,7 @@ STATIC_IMAGE_LIST=(
 # dynamic list
 git checkout origin/track/0.10
 IMAGE_LIST=()
+IMAGE_LIST+=($(find $REPO -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2 | awk '{print $2}' | sort --unique))
 IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/configmap_manifests.yaml.j2 | awk '{print $3}' | sort --unique | sed s/,//g | sed s/\"//g))
 

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+)
+# dynamic list
+git checkout origin/track/0.10
+IMAGE_LIST=()
+IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2 | awk '{print $2}' | sort --unique))
+IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/configmap_manifests.yaml.j2 | awk '{print $3}' | sort --unique | sed s/,//g | sed s/\"//g))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Added script to extract images for stable.