### PR TITLE
fix: use local_gateway info properly

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -472,7 +472,7 @@ class KServeControllerCharm(CharmBase):
                 gateways_context.update(
                     {
                         "local_gateway_name": local_gateway_info["gateway_name"],
-                        "local_gateway_namespace": ingress_gateway_info["gateway_namespace"],
+                        "local_gateway_namespace": local_gateway_info["gateway_namespace"],
                         "local_gateway_service_name": "knative-local-gateway",
                     }
                 )


### PR DESCRIPTION
This commit corrects the context that is used for rendering the ingress ConfigMap, instead of using the ingress_gateway, use the local_gateway info when the kserve-controller charm is related to KNative and is set to serverless mode.

Fixes #150