### PR TITLE
fix: modified to retrieve images only from one charm

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -4,7 +4,9 @@
 #
 # dynamic list
 IMAGE_LIST=()
-IMAGE_LIST+=($(find $REPO -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+# only scan kserve-controller to avoid retrieving incorrect image from kserve-web-app
+# details are in https://github.com/canonical/bundle-kubeflow/issues/674
+IMAGE_LIST+=($(find charms/kserve-controller/ -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2 | awk '{print $2}' | sort --unique))
 IMAGE_LIST+=($(grep image charms/kserve-controller/src/templates/configmap_manifests.yaml.j2 | awk '{print $3}' | sort --unique | sed s/,//g | sed s/\"//g))
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
# Description
`kserve-web-app` is not deployed as part of 1.7 release. Get images script incorrectly retrieves image from `kserve-web-app` charm which incorrectly shows up on report of deployable images.
This changes will address the issue by only scanning charm that is deployed in 1.7 release.

More details are in https://github.com/canonical/bundle-kubeflow/issues/674

Summary of changes:
- Modified script to retrieve images only from kserve-controller, because kserve-web-app is not deployed in this release.

NOTE: This change is only applicable to track/0.10