### PR TITLE
Kf 4223 fix do not publish kserve web app charm

### DIFF
--- a/.github/workflows/get-charm-paths.sh
+++ b/.github/workflows/get-charm-paths.sh
@@ -24,7 +24,9 @@ fi
 # Convert output to JSON string format
 # { charm_paths: [...] }
 
-CHARM_PATHS_LIST=$(echo "$CHARM_PATHS" | jq -c --slurp --raw-input 'split("\n")[:-1]')
+# Porting fix: https://github.com/canonical/kserve-operators/commit/1263f31763286dc3155f354d19de6d7f9f1472a8
+# which was done on `main` as part of https://github.com/canonical/kserve-operators/pull/141
+CHARM_PATHS_LIST=["./charms/kserve-controller"]
 
 # FIXME: kserve-web-app is not ready to be built and published, the publish job for
 # that charm is expected to fail. It can be ignored until the charm is not WIP.


### PR DESCRIPTION
fix: ported fix for failing charm publish
Details are in: https://github.com/canonical/kserve-operators/issues/156
    
Summary of changes:
- Updated workflow not to include kserve-web-app charm in list of charms for publishing.

NOTE: This PR is porting fix that was done on `main` into `tracjk/0.10`. Refer to the issue linked to this PR for more details.