### PR TITLE
fix: Parse custom images with ":" in their name

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -294,7 +294,7 @@ class KServeControllerCharm(CharmBase):
         ]:
             images[f"{image_name}__image"], images[f"{image_name}__version"] = images[
                 image_name
-            ].split(":")
+            ].rsplit(":", 1)
         return images
 
     def _on_kserve_controller_ready(self, event):


### PR DESCRIPTION
For 3 of the images (i.e. explainers), the charm attempts to separate the image name from the tag, splitting the string in two using `:` as a separator. However, this breaks the installation if the image name contains that special character, which could be the case if a local container registry address is provided for instance (e.g. `172.17.0.2:5000/kserve/alibi-explainer:latest`).

Use `rsplit` to ensure that the rightmost part of the string (following the last `:`) is parsed as the tag.

Closes #159