### PR TITLE
fix: get images on main

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+# only scan kserve-controller to avoid retrieving incorrect image from kserve-web-app
+# details are in https://github.com/canonical/bundle-kubeflow/issues/674
+IMAGE_LIST+=($(find charms/kserve-controller/ -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(yq '.[]' ./charms/kserve-controller/src/default-custom-images.json  | sed 's/"//g'))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
# Descripton
Details on the issue and design are in: https://github.com/canonical/kserve-operators/issues/162

Summary of changes:
- Added scrip to retrieve images referenced in kserve

NOTE: This PR should be merged after https://github.com/canonical/kserve-operators/pull/163