### PR TITLE
fix: use local_gateway info properly (#154)

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -373,7 +373,7 @@ class KServeControllerCharm(CharmBase):
                 gateways_context.update(
                     {
                         "local_gateway_name": local_gateway_info["gateway_name"],
-                        "local_gateway_namespace": ingress_gateway_info["gateway_namespace"],
+                        "local_gateway_namespace": local_gateway_info["gateway_namespace"],
                         "local_gateway_service_name": "knative-local-gateway",
                     }
                 )

--- a/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
@@ -60,7 +60,7 @@ data:
       "ingressClassName" : "istio",
       {% if local_gateway_namespace and local_gateway_name -%}
       "localGateway" : "{{ local_gateway_namespace }}/{{ local_gateway_name }}",
-      "localGatewayService" : "{{ local_gateway_service_name }}.{{ local_gateway_namespace}}.svc.cluster.local",
+      "localGatewayService" : "{{ local_gateway_service_name }}.{{ ingress_gateway_namespace}}.svc.cluster.local",
       {%- endif %}
       "urlScheme": "http"
     }

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -24,6 +24,31 @@ KNATIVE_VERSION = "latest/edge"
 ISTIO_INGRESS_GATEWAY = "test-gateway"
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+CONFIGMAP_NAME = "inferenceservice-config"
+EXPECTED_CONFIGMAP = {
+    "agent": '{\n    "image" : "kserve/agent:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1"\n}',
+    "batcher": '{\n    "image" : "kserve/agent:v0.10.0",\n    "memoryRequest": "1Gi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "1",\n    "cpuLimit": "1"\n}',
+    "credentials": '{\n   "gcs": {\n       "gcsCredentialFileName": "gcloud-application-credentials.json"\n   },\n   "s3": {\n       "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",\n       "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",\n       "s3Endpoint": "",\n       "s3UseHttps": "",\n       "s3Region": "",\n       "s3VerifySSL": "",\n       "s3UseVirtualBucket": "",\n       "s3UseAnonymousCredential": "",\n       "s3CABundle": ""\n   }\n}',
+    "deploy": '{\n  "defaultDeploymentMode": "Serverless"\n}',
+    "explainers": '{\n    "alibi": {\n        "image" : "kserve/alibi-explainer",\n        "defaultImageVersion": "latest"\n    },\n    "aix": {\n        "image" : "kserve/aix-explainer",\n        "defaultImageVersion": "latest"\n    },\n    "art": {\n        "image" : "kserve/art-explainer",\n        "defaultImageVersion": "latest"\n    }\n}',
+    "ingress": '{\n  "ingressGateway" : "kubeflow/test-gateway",\n  "ingressService" : "istio-ingressgateway-workload.kubeflow.svc.cluster.local",\n  "ingressDomain"  : "example.com",\n  "ingressClassName" : "istio",\n  "localGateway" : "knative-serving/knative-local-gateway",\n  "localGatewayService" : "knative-local-gateway.kubeflow.svc.cluster.local",\n  "urlScheme": "http"\n}',
+    "logger": '{\n    "image" : "kserve/agent:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1",\n    "defaultUrl": "http://default-broker"\n}',
+    "metricsAggregator": '{\n  "enableMetricAggregation": "false",\n  "enablePrometheusScraping" : "false"\n}',
+    "router": '{\n    "image" : "kserve/router:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1"\n}',
+    "storageInitializer": '{\n    "image" : "kserve/storage-initializer:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1",\n    "storageSpecSecretName": "storage-config"\n}',
+}
+EXPECTED_CONFIGMAP_CHANGED = {
+    "agent": '{\n    "image" : "kserve/agent:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1"\n}',
+    "batcher": '{\n    "image" : "custom:1.0",\n    "memoryRequest": "1Gi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "1",\n    "cpuLimit": "1"\n}',
+    "credentials": '{\n   "gcs": {\n       "gcsCredentialFileName": "gcloud-application-credentials.json"\n   },\n   "s3": {\n       "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",\n       "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",\n       "s3Endpoint": "",\n       "s3UseHttps": "",\n       "s3Region": "",\n       "s3VerifySSL": "",\n       "s3UseVirtualBucket": "",\n       "s3UseAnonymousCredential": "",\n       "s3CABundle": ""\n   }\n}',
+    "deploy": '{\n  "defaultDeploymentMode": "Serverless"\n}',
+    "explainers": '{\n    "alibi": {\n        "image" : "custom",\n        "defaultImageVersion": "2.1"\n    },\n    "aix": {\n        "image" : "kserve/aix-explainer",\n        "defaultImageVersion": "latest"\n    },\n    "art": {\n        "image" : "kserve/art-explainer",\n        "defaultImageVersion": "latest"\n    }\n}',
+    "ingress": '{\n  "ingressGateway" : "kubeflow/test-gateway",\n  "ingressService" : "istio-ingressgateway-workload.kubeflow.svc.cluster.local",\n  "ingressDomain"  : "example.com",\n  "ingressClassName" : "istio",\n  "localGateway" : "knative-serving/knative-local-gateway",\n  "localGatewayService" : "knative-local-gateway.kubeflow.svc.cluster.local",\n  "urlScheme": "http"\n}',
+    "logger": '{\n    "image" : "kserve/agent:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1",\n    "defaultUrl": "http://default-broker"\n}',
+    "metricsAggregator": '{\n  "enableMetricAggregation": "false",\n  "enablePrometheusScraping" : "false"\n}',
+    "router": '{\n    "image" : "kserve/router:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1"\n}',
+    "storageInitializer": '{\n    "image" : "kserve/storage-initializer:v0.10.0",\n    "memoryRequest": "100Mi",\n    "memoryLimit": "1Gi",\n    "cpuRequest": "100m",\n    "cpuLimit": "1",\n    "storageSpecSecretName": "storage-config"\n}',
+}
 
 
 @pytest.fixture


### PR DESCRIPTION
* fix: use local_gateway info properly

This commit corrects the context that is used for rendering the ingress ConfigMap, instead of using the ingress_gateway, use the local_gateway info when the kserve-controller charm is related to KNative and is set to serverless mode.

Fixes #150