### PR TITLE
Run kserve-controller in serverless mode by default

### DIFF
--- a/charms/kserve-controller/config.yaml
+++ b/charms/kserve-controller/config.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 options:
   deployment-mode:
-    default: "RawDeployment"
+    default: "serverless"
     description: Deployment mode for kserve. It can only be RawDeployment or Serverless, and the latter requires knative-serving to be present in the model, and the local-gateway relation to be established.
     type: string
   domain-name:

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -86,7 +86,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
         ],
         "kube-rbac-proxy-image": METADATA["resources"]["kube-rbac-proxy-image"]["upstream-source"],
     }
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, trust=True)
+    await ops_test.model.deploy(
+        charm,
+        resources=resources,
+        config={"deployment-mode": "rawdeployment"},
+        application_name=APP_NAME,
+        trust=True,
+    )
     await ops_test.model.add_relation("istio-pilot", "kserve-controller")
 
     # issuing dummy update_status just to trigger an event


### PR DESCRIPTION
Set default config to `serverless`. 

In integration tests we first run tests for `rawdeployment` mode and then the tests set the `serverless` config.