### PR TITLE
Integrate with resource dispatcher

### DIFF
--- a/charms/kserve-controller/metadata.yaml
+++ b/charms/kserve-controller/metadata.yaml
@@ -24,9 +24,63 @@ resources:
     description: OCI image for kube rbac proxy
     upstream-source: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
 requires:
+  object-storage:
+    interface: object-storage
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
+    versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
   ingress-gateway:
     interface: istio-gateway-info
     limit: 1
   local-gateway:
     interface: serving-local-gateway
     limit: 1
+provides:
+  secrets:
+    interface: secrets
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            secrets:
+              type: string
+        required:
+        - secrets
+    versions: [v1]
+  service-accounts:
+    interface: service-accounts
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-accounts:
+              type: string
+        required:
+        - service-accounts
+    versions: [v1]

--- a/charms/kserve-controller/requirements-fmt.txt
+++ b/charms/kserve-controller/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==23.9.1
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
 isort==5.12.0
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via black
 tomli==2.0.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via black

--- a/charms/kserve-controller/requirements-integration.in
+++ b/charms/kserve-controller/requirements-integration.in
@@ -1,4 +1,5 @@
 aiohttp
+charmed-kubeflow-chisme
 jinja2
 # Pinning to <4.0 due to compatibility with the 3.1 controller version
 juju<4.0

--- a/charms/kserve-controller/requirements-integration.txt
+++ b/charms/kserve-controller/requirements-integration.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-integration.in
 #
-aiohttp==3.8.5
+aiohttp==3.8.6
     # via -r requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
@@ -15,7 +15,9 @@ asttokens==2.4.0
 async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   jsonschema
 backcall==0.2.0
     # via ipython
 bcrypt==4.0.1
@@ -28,31 +30,35 @@ certifi==2023.7.22
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charmed-kubeflow-chisme==0.2.0
+    # via -r requirements-integration.in
+charset-normalizer==3.3.0
     # via
     #   aiohttp
     #   requests
-cryptography==41.0.3
+cryptography==41.0.4
     # via paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+deepdiff==6.2.1
+    # via charmed-kubeflow-chisme
 exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
-executing==1.2.0
+executing==2.0.0
     # via stack-data
 frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.23.0
+google-auth==2.23.3
     # via kubernetes
 h11==0.14.0
     # via httpcore
@@ -68,26 +74,33 @@ idna==3.4
     #   httpx
     #   requests
     #   yarl
+importlib-resources==6.1.0
+    # via jsonschema
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-jedi==0.19.0
+jedi==0.19.1
     # via ipython
 jinja2==3.1.2
     # via
     #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
     #   pytest-operator
+jsonschema==4.17.3
+    # via serialized-data-interface
 juju==3.2.2
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-kubernetes==27.2.0
+kubernetes==28.1.0
     # via juju
 lightkube==0.14.0
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
@@ -106,7 +119,13 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.1
+ops==2.7.0
+    # via
+    #   charmed-kubeflow-chisme
+    #   serialized-data-interface
+ordered-set==4.1.0
+    # via deepdiff
+packaging==23.2
     # via pytest
 paramiko==2.12.0
     # via juju
@@ -116,6 +135,8 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.39
@@ -150,6 +171,8 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
+pyrsistent==0.19.3
+    # via jsonschema
 pytest==7.4.2
     # via
     #   pytest-asyncio
@@ -167,7 +190,9 @@ pyyaml==6.0.1
     #   juju
     #   kubernetes
     #   lightkube
+    #   ops
     #   pytest-operator
+    #   serialized-data-interface
 requests==2.31.0
     # via
     #   -r requirements-integration.in
@@ -175,10 +200,17 @@ requests==2.31.0
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
+    #   serialized-data-interface
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruamel-yaml==0.17.35
+    # via charmed-kubeflow-chisme
+ruamel-yaml-clib==0.2.8
+    # via ruamel-yaml
+serialized-data-interface==0.7.0
+    # via charmed-kubeflow-chisme
 six==1.16.0
     # via
     #   asttokens
@@ -192,36 +224,41 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
 tenacity==8.2.3
-    # via -r requirements-integration.in
+    # via
+    #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
 tomli==2.0.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.9.0
+traitlets==5.11.2
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   ipython
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==1.26.16
+urllib3==1.26.17
     # via
-    #   google-auth
     #   kubernetes
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.8
     # via prompt-toolkit
-websocket-client==1.6.3
-    # via kubernetes
+websocket-client==1.6.4
+    # via
+    #   kubernetes
+    #   ops
 websockets==8.1
     # via juju
 yarl==1.9.2
     # via aiohttp
+zipp==3.17.0
+    # via importlib-resources

--- a/charms/kserve-controller/requirements-lint.txt
+++ b/charms/kserve-controller/requirements-lint.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==23.9.1
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.2.6
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==6.1.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
@@ -26,25 +26,25 @@ mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
 pep8-naming==0.13.3
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==6.1.0
     # via -r requirements-lint.in
 tomli==2.0.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/kserve-controller/requirements-unit.txt
+++ b/charms/kserve-controller/requirements-unit.txt
@@ -4,61 +4,76 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==3.7.1
+anyio==4.0.0
     # via httpcore
+attrs==23.1.0
+    # via jsonschema
 certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
-charmed-kubeflow-chisme==0.0.11
+    #   requests
+charmed-kubeflow-chisme==0.2.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
-coverage==7.2.7
+charset-normalizer==3.3.0
+    # via requests
+coverage==7.3.2
     # via -r requirements-unit.in
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==0.18.0
     # via httpx
-httpx==0.24.1
+httpx==0.25.0
     # via lightkube
 idna==3.4
     # via
     #   anyio
     #   httpx
+    #   requests
+importlib-resources==6.1.0
+    # via jsonschema
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via charmed-kubeflow-chisme
+jsonschema==4.17.3
+    # via serialized-data-interface
 lightkube==0.14.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.28.1.4
     # via
     #   -r requirements.in
     #   lightkube
 markupsafe==2.1.3
     # via jinja2
-ops==2.4.1
+ops==2.7.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
+    #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
+packaging==23.2
     # via pytest
-pluggy==1.2.0
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
+pluggy==1.3.0
     # via pytest
-pytest==7.4.0
+pyrsistent==0.19.3
+    # via jsonschema
+pytest==7.4.2
     # via
     #   -r requirements-unit.in
     #   pytest-mock
@@ -69,18 +84,29 @@ pyyaml==6.0.1
     #   -r requirements.in
     #   lightkube
     #   ops
-ruamel-yaml==0.17.32
+    #   serialized-data-interface
+requests==2.31.0
+    # via serialized-data-interface
+ruamel-yaml==0.17.35
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
+serialized-data-interface==0.7.0
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
 sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.2.3
     # via charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
-websocket-client==1.6.1
+urllib3==2.0.6
+    # via requests
+websocket-client==1.6.4
     # via ops
+zipp==3.17.0
+    # via importlib-resources

--- a/charms/kserve-controller/requirements.in
+++ b/charms/kserve-controller/requirements.in
@@ -3,3 +3,4 @@ lightkube
 lightkube-models
 ops
 pyyaml==6.0.1
+serialized-data-interface

--- a/charms/kserve-controller/requirements.txt
+++ b/charms/kserve-controller/requirements.txt
@@ -4,61 +4,87 @@
 #
 #    pip-compile requirements.in
 #
-anyio==3.7.1
+anyio==4.0.0
     # via httpcore
+attrs==23.1.0
+    # via jsonschema
 certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
-charmed-kubeflow-chisme==0.0.11
+    #   requests
+charmed-kubeflow-chisme==0.2.0
     # via -r requirements.in
+charset-normalizer==3.3.0
+    # via requests
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via anyio
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==0.18.0
     # via httpx
-httpx==0.24.1
+httpx==0.25.0
     # via lightkube
 idna==3.4
     # via
     #   anyio
     #   httpx
+    #   requests
+importlib-resources==6.1.0
+    # via jsonschema
 jinja2==3.1.2
     # via charmed-kubeflow-chisme
+jsonschema==4.17.3
+    # via serialized-data-interface
 lightkube==0.14.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.28.1.4
     # via
     #   -r requirements.in
     #   lightkube
 markupsafe==2.1.3
     # via jinja2
-ops==2.4.1
+ops==2.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
+    #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
+pyrsistent==0.19.3
+    # via jsonschema
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   lightkube
     #   ops
-ruamel-yaml==0.17.32
+    #   serialized-data-interface
+requests==2.31.0
+    # via serialized-data-interface
+ruamel-yaml==0.17.35
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
+serialized-data-interface==0.7.0
+    # via
+    #   -r requirements.in
+    #   charmed-kubeflow-chisme
 sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.2.3
     # via charmed-kubeflow-chisme
-websocket-client==1.6.1
+urllib3==2.0.6
+    # via requests
+websocket-client==1.6.4
     # via ops
+zipp==3.17.0
+    # via importlib-resources

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -462,7 +462,7 @@ class KServeControllerCharm(CharmBase):
 
         secrets_context = {
             "secret_name": f"{self.app.name}-s3",
-            "s3_endpoint": f"http://{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
+            "s3_endpoint": f"{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
             "s3_usehttps": S3_USEHTTPS,
             "s3_region": S3_REGION,
             "s3_useanoncredential": S3_USEANONCREDENTIALS,

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -81,6 +81,7 @@ SECRETS_FILES = [
 SERVICE_ACCOUNTS_FILES = [
     "src/service-accounts/kserve-mlflow-minio-svc-account.yaml.j2",
 ]
+NO_MINIO_RELATION_DATA = {}
 
 
 def parse_images_config(config: str) -> Dict:
@@ -452,12 +453,11 @@ class KServeControllerCharm(CharmBase):
 
     def send_object_storage_manifests(self):
         """Send object storage related manifests in case the object storage relation exists"""
-        default_return = {}
         interfaces = self._get_interfaces()
-        object_storage_data = self._get_object_storage(interfaces, default_return)
+        object_storage_data = self._get_object_storage(interfaces, NO_MINIO_RELATION_DATA)
 
-        # Relation is not present, return
-        if object_storage_data == default_return:
+        # Relation is not present
+        if object_storage_data == NO_MINIO_RELATION_DATA:
             return
 
         secrets_context = {

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -15,6 +15,7 @@ develop a new k8s charm using the Operator Framework:
 import json
 import logging
 from base64 import b64encode
+from pathlib import Path
 from typing import Dict
 
 import yaml
@@ -27,6 +28,8 @@ from charms.istio_pilot.v0.istio_gateway_info import (
     GatewayRelationMissingError,
     GatewayRequirer,
 )
+from jinja2 import Template
+from jsonschema import ValidationError
 from lightkube import ApiError
 from ops.charm import CharmBase
 from ops.framework import StoredState
@@ -40,6 +43,13 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import APIError, Layer, PathError, ProtocolError
+from serialized_data_interface import (
+    NoCompatibleVersions,
+    NoVersionsListed,
+    SerializedDataInterface,
+    get_interfaces,
+)
+from serialized_data_interface.errors import RelationDataError
 
 from certs import gen_certs
 
@@ -58,6 +68,18 @@ K8S_RESOURCE_FILES = [
     "src/templates/auth_manifests.yaml.j2",
     "src/templates/serving_runtimes_manifests.yaml.j2",
     "src/templates/webhook_manifests.yaml.j2",
+]
+
+# Values for MinIO manifests https://kserve.github.io/website/0.11/modelserving/storage/s3/s3/
+S3_USEANONCREDENTIALS = "false"
+S3_REGION = "us-east-1"
+S3_USEHTTPS = "0"
+
+SECRETS_FILES = [
+    "src/secrets/kserve-mlflow-minio-secret.yaml.j2",
+]
+SERVICE_ACCOUNTS_FILES = [
+    "src/service-accounts/kserve-mlflow-minio-svc-account.yaml.j2",
 ]
 
 
@@ -122,6 +144,8 @@ class KServeControllerCharm(CharmBase):
         self.framework.observe(
             self.on["local-gateway"].relation_broken, self._on_local_gateway_relation_broken
         )
+        for rel in ["object-storage", "secrets", "service-accounts"]:
+            self.framework.observe(self.on[rel].relation_changed, self._on_install)
 
         self._k8s_resource_handler = None
         self._crd_resource_handler = None
@@ -243,6 +267,101 @@ class KServeControllerCharm(CharmBase):
         """Returns the local gateway info."""
         return self._local_gateway_requirer.get_relation_data()
 
+    def _get_interfaces(self):
+        # Remove this abstraction when SDI adds .status attribute to NoVersionsListed,
+        # NoCompatibleVersionsListed:
+        # https://github.com/canonical/serialized-data-interface/issues/26
+        try:
+            interfaces = get_interfaces(self)
+        except NoVersionsListed as err:
+            raise ErrorWithStatus((err), WaitingStatus)
+        except NoCompatibleVersions as err:
+            raise ErrorWithStatus(str(err), BlockedStatus)
+        except RelationDataError as err:
+            raise ErrorWithStatus(str(err), BlockedStatus)
+        return interfaces
+
+    def _validate_sdi_interface(self, interfaces: dict, relation_name: str, default_return=None):
+        """Validates data received from SerializedDataInterface, returning the data if valid.
+
+        Optionally can return a default_return value when no relation is established
+
+        Raises:
+            ErrorWithStatus(..., Blocked) when no relation established (unless default_return set)
+            ErrorWithStatus(..., Blocked) if interface is not using SDI
+            ErrorWithStatus(..., Blocked) if data in interface fails schema check
+            ErrorWithStatus(..., Waiting) if we have a relation established but no data passed
+
+        Params:
+            interfaces:
+
+        Returns:
+              (dict) interface data
+        """
+        # If nothing is related to this relation, return a default value or raise an error
+        if relation_name not in interfaces or interfaces[relation_name] is None:
+            return default_return
+
+        relations = interfaces[relation_name]
+        if not isinstance(relations, SerializedDataInterface):
+            raise ErrorWithStatus(
+                f"Unexpected error with {relation_name} relation data - data not as expected",
+                BlockedStatus,
+            )
+
+        # Get and validate data from the relation
+        try:
+            # relations is a dict of {(ops.model.Relation, ops.model.Application): data}
+            unpacked_relation_data = relations.get_data()
+        except ValidationError as val_error:
+            # Validation in .get_data() ensures if data is populated, it matches the schema and is
+            # not incomplete
+            self.logger.error(val_error)
+            raise ErrorWithStatus(
+                f"Found incomplete/incorrect relation data for {relation_name}. See logs",
+                BlockedStatus,
+            )
+
+        # Check if we have an established relation with no data exchanged
+        if len(unpacked_relation_data) == 0:
+            raise ErrorWithStatus(f"Waiting for {relation_name} relation data", WaitingStatus)
+
+        # Unpack data (we care only about the first element)
+        data_dict = list(unpacked_relation_data.values())[0]
+
+        # Catch if empty data dict is received (JSONSchema ValidationError above does not raise
+        # when this happens)
+        # Remove once addressed in:
+        # https://github.com/canonical/serialized-data-interface/issues/28
+        if len(data_dict) == 0:
+            raise ErrorWithStatus(
+                f"Found empty relation data for {relation_name}",
+                BlockedStatus,
+            )
+
+        return data_dict
+
+    def _get_object_storage(self, interfaces, default_return):
+        """Retrieve object-storage relation data."""
+        relation_name = "object-storage"
+        return self._validate_sdi_interface(interfaces, relation_name, default_return)
+
+    def _send_manifests(self, interfaces, context, manifest_files, relation):
+        """Send manifests from folder to desired relation."""
+        if relation in interfaces and interfaces[relation]:
+            manifests = self._create_manifests(manifest_files, context)
+            interfaces[relation].send_data({relation: manifests})
+
+    def _create_manifests(self, manifest_files, context):
+        """Create manifests string for given folder and context."""
+        manifests = []
+        for file in manifest_files:
+            template = Template(Path(file).read_text())
+            rendered_template = template.render(**context)
+            manifest = yaml.safe_load(rendered_template)
+            manifests.append(manifest)
+        return json.dumps(manifests)
+
     def get_images(
         self, default_images: Dict[str, str], custom_images: Dict[str, str]
     ) -> Dict[str, str]:
@@ -331,6 +450,36 @@ class KServeControllerCharm(CharmBase):
         # TODO determine status checking if controller is also up
         self.unit.status = ActiveStatus()
 
+    def send_object_storage_manifests(self):
+        """Send object storage related manifests in case the object storage relation exists"""
+        default_return = {}
+        interfaces = self._get_interfaces()
+        object_storage_data = self._get_object_storage(interfaces, default_return)
+
+        # Relation is not present, return
+        if object_storage_data == default_return:
+            return
+
+        secrets_context = {
+            "secret_name": f"{self.app.name}-s3",
+            "s3_endpoint": f"http://{object_storage_data['service']}.{object_storage_data['namespace']}:{object_storage_data['port']}",  # noqa: E501
+            "s3_usehttps": S3_USEHTTPS,
+            "s3_region": S3_REGION,
+            "s3_useanoncredential": S3_USEANONCREDENTIALS,
+            "s3_access_key": object_storage_data["access-key"],
+            "s3_secret_access_key": object_storage_data["secret-key"],
+        }
+
+        service_accounts_context = {
+            "svc_account_name": f"{self.app.name}-s3",
+            "secret_name": f"{self.app.name}-s3",
+        }
+
+        self._send_manifests(interfaces, secrets_context, SECRETS_FILES, "secrets")
+        self._send_manifests(
+            interfaces, service_accounts_context, SERVICE_ACCOUNTS_FILES, "service-accounts"
+        )
+
     def _on_install(self, event):
         try:
             self.custom_images = parse_images_config(self.model.config["custom_images"])
@@ -338,6 +487,7 @@ class KServeControllerCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Creating k8s resources")
             self.k8s_resource_handler.apply()
             self.cm_resource_handler.apply()
+            self.send_object_storage_manifests()
 
             # The kserve-controller service must be restarted whenever the
             # configuration is changed, otherwise the service will remain

--- a/charms/kserve-controller/src/secrets/kserve-mlflow-minio-secret.yaml.j2
+++ b/charms/kserve-controller/src/secrets/kserve-mlflow-minio-secret.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  annotations:
+     serving.kserve.io/s3-endpoint: "{{ s3_endpoint }}"
+     serving.kserve.io/s3-usehttps: "{{ s3_usehttps }}"
+     serving.kserve.io/s3-region: "{{ s3_region }}"
+     serving.kserve.io/s3-useanoncredential: "{{s3_useanoncredential }}"
+type: Opaque
+stringData: # use `stringData` for raw credential string or `data` for base64 encoded string
+  AWS_ACCESS_KEY_ID: {{ s3_access_key }}
+  AWS_SECRET_ACCESS_KEY: {{ s3_secret_access_key }}

--- a/charms/kserve-controller/src/service-accounts/kserve-mlflow-minio-svc-account.yaml.j2
+++ b/charms/kserve-controller/src/service-accounts/kserve-mlflow-minio-svc-account.yaml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ svc_account_name }}
+secrets:
+- name: {{ secret_name }}

--- a/charms/kserve-controller/tests/integration/crds/poddefaults.yaml
+++ b/charms/kserve-controller/tests/integration/crds/poddefaults.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: poddefaults.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: PodDefault
+    plural: poddefaults
+    singular: poddefault
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                desc:
+                  type: string
+                serviceAccountName:
+                  type: string
+                automountServiceAccountToken:
+                  type: boolean
+                env:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                envFrom:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                selector:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                volumeMounts:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                volumes:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - selector
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/charms/kserve-controller/tests/integration/namespace.yaml
+++ b/charms/kserve-controller/tests/integration/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels: {}
+  name: test-namespace-resource-dispatcher
+

--- a/charms/kserve-controller/tests/test_data/secret.yaml.j2
+++ b/charms/kserve-controller/tests/test_data/secret.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  annotations:
+     serving.kserve.io/s3-endpoint: "{{ s3_endpoint }}"
+     serving.kserve.io/s3-usehttps: "{{ s3_usehttps }}"
+     serving.kserve.io/s3-region: "{{ s3_region }}"
+     serving.kserve.io/s3-useanoncredential: "{{s3_useanoncredential }}"
+type: Opaque
+stringData: # use `stringData` for raw credential string or `data` for base64 encoded string
+  AWS_ACCESS_KEY_ID: {{ s3_access_key }}
+  AWS_SECRET_ACCESS_KEY: {{ s3_secret_access_key }}

--- a/charms/kserve-controller/tests/test_data/service-account-yaml.j2
+++ b/charms/kserve-controller/tests/test_data/service-account-yaml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ svc_account_name }}
+secrets:
+- name: {{ secret_name }}


### PR DESCRIPTION
Kserve now can be integrated with resource dispatcher to be able to serve models from MLflow. In order to do that following manifests need to be created in user namespaces (secret and svc abbount with credentials to connect to object store) https://kserve.github.io/website/0.11/modelserving/storage/s3/s3/#deploy-the-model-on-s3-with-inferenceservice 

This PR:
- allows kserve to relate to minio (this is optional relation because kserve can work also without it).
- sends secrets and service accounts to resource dispatcher through relations

Integration tests are deploying metacontroller, poddefaults crd minio and resource dispatcher to simulate the usecase. An example labeled user namespace is created and the test check that the user manifests are created. 