### PR TITLE
fix: bump mlserver version to 1.3.5

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -8,7 +8,7 @@
     "configmap__router": "kserve/router:v0.10.0",
     "configmap__storageInitializer": "kserve/storage-initializer:v0.10.0",
     "serving_runtimes__lgbserver": "kserve/lgbserver:v0.10.0",
-    "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.0.0",
+    "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.3.5",
     "serving_runtimes__paddleserver": "kserve/paddleserver:v0.10.0",
     "serving_runtimes__pmmlserver": "kserve/pmmlserver:v0.10.0",
     "serving_runtimes__sklearnserver": "kserve/sklearnserver:v0.10.0",


### PR DESCRIPTION
Summary of changes:
- Bump version of mlserver to 1.3.5 to have image with less CVEs.