### PR TITLE
bump image to match kf 1.8

### DIFF
--- a/charms/kserve-controller/metadata.yaml
+++ b/charms/kserve-controller/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   kserve-controller-image:
     type: oci-image
     description: OCI image for kserve controller
-    upstream-source: kserve/kserve-controller:v0.11.0
+    upstream-source: kserve/kserve-controller:v0.11.1
   kube-rbac-proxy-image:
     type: oci-image
     description: OCI image for kube rbac proxy


### PR DESCRIPTION
matches images cited in https://github.com/kubeflow/manifests/releases/tag/v1.8.0

See [this discussion](https://chat.charmhub.io/charmhub/pl/611bhrdxtbd5pk5qn47zrsy8gy) before merging to confirm this is the version we wanted.