### PR TITLE
fix: use an all-catch main event handler

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -464,10 +464,6 @@ class KServeControllerCharm(CharmBase):
             raise
         self.model.unit.status = ActiveStatus()
 
-    def _on_config_changed(self, event):
-        """Handle the config changed event."""
-        self._on_event(event)
-
     def _on_remove(self, event):
         try:
             self.custom_images = parse_images_config(self.model.config["custom_images"])

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -132,13 +132,13 @@ class KServeControllerCharm(CharmBase):
             self.on.kube_rbac_proxy_pebble_ready,
             self.on["local-gateway"].relation_changed,
             self.on["ingress-gateway"].relation_changed,
+            self.on["object-storage"].relation_changed,
+            self.on["secrets"].relation_changed,
+            self.on["service-accounts"].relation_changed,
             self.on["ingress-gateway"].relation_broken,
             self.on["local-gateway"].relation_broken,
         ]:
             self.framework.observe(event, self._on_event)
-
-        for rel in ["object-storage", "secrets", "service-accounts"]:
-            self.framework.observe(self.on[rel].relation_changed, self._on_event)
 
         self._k8s_resource_handler = None
         self._crd_resource_handler = None

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -122,6 +122,7 @@ def lightkube_client() -> lightkube.Client:
     return client
 
 
+@pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it together with related charms.

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -193,6 +193,25 @@ def test_on_kserve_controller_ready_active(harness, mocked_resource_handler, moc
     # assert harness.get_container_pebble_plan("kserve-controller")._services != {}
 
 
+def test_on_kserve_controller_ready_no_relation_blocked(harness, mocked_resource_handler, mocker):
+    """Tests that charm goes to blocked when it has no relation to knative-serving."""
+    harness.begin()
+
+    # Add relation with ingress-gateway providers
+    relation_id_ingress = harness.add_relation("ingress-gateway", "test-istio-pilot")
+
+    # Updated the data bag with ingress-gateway
+    remote_ingress_data = {
+        "gateway_name": "test-ingress-name",
+        "gateway_namespace": "test-ingress-namespace",
+    }
+    harness.update_relation_data(relation_id_ingress, "test-istio-pilot", remote_ingress_data)
+
+    assert harness.model.unit.status == BlockedStatus(
+        "Please relate to knative-serving:local-gateway"
+    )
+
+
 def test_on_remove_success(harness, mocker, mocked_resource_handler):
     mocked_delete_many = mocker.patch("charm.delete_many")
     harness.begin()


### PR DESCRIPTION
Refactors the `kserve-controller` charm to have an `on_event` event handler that handles events with common behavior.
fixes #194 