### PR TITLE
ci: set automatically-retry-hooks to false

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,7 @@ jobs:
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
       - run: |
-          juju add-model kubeflow --config default-series=focal --config automatically-retry-hooks=true
+          juju add-model kubeflow --config default-series=focal --config automatically-retry-hooks=false
           tox -e ${{ matrix.charm }}-integration -- --model kubeflow -vv -s
 
       - name: Get all


### PR DESCRIPTION
By default, Juju automatically retries any failed hook (any event that raises an uncaught exception).  This is often helpful, but in our CI it might hide transient errors that we would want to fix.  We should disable this behavior in our test environment.

closes #202 

should be merged after #203 