### PR TITLE
tests: pin charm dependencies to stable channels that correspond to CKF 1.8

### DIFF
--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -404,7 +404,7 @@ async def test_configmap_changes_with_config(
 async def test_relate_to_object_store(ops_test: OpsTest):
     """Test if the charm can relate to minio and stay in Active state"""
     await ops_test.model.deploy(
-        OBJECT_STORAGE_CHARM_NAME, channel="ckf-1.7/stable", config=OBJECT_STORAGE_CONFIG
+        OBJECT_STORAGE_CHARM_NAME, channel="ckf-1.8/stable", config=OBJECT_STORAGE_CONFIG
     )
     await ops_test.model.wait_for_idle(
         apps=[OBJECT_STORAGE_CHARM_NAME],
@@ -433,7 +433,7 @@ async def test_deploy_resource_dispatcher(ops_test: OpsTest):
     deploy_k8s_resources([PODDEFAULTS_CRD_TEMPLATE])
     await ops_test.model.deploy(
         entity_url=METACONTROLLER_CHARM_NAME,
-        channel="latest/edge",
+        channel="3.0/stable",
         trust=True,
     )
     await ops_test.model.wait_for_idle(
@@ -443,7 +443,7 @@ async def test_deploy_resource_dispatcher(ops_test: OpsTest):
         raise_on_error=False,
         timeout=120,
     )
-    await ops_test.model.deploy(RESOURCE_DISPATCHER_CHARM_NAME, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(RESOURCE_DISPATCHER_CHARM_NAME, channel="1.0/stable", trust=True)
     await ops_test.model.wait_for_idle(
         apps=[CHARM_NAME],
         status="active",


### PR DESCRIPTION

Because charms in latest/edge change often and the 0.11 version of kserve was initially tested using different versions of charms (metacontroller, minio, resource dispatcher), we need to ensure this testing environment is kept as it was back then. Pinning those dependencies to the right version to avoid future isssues.