### PR TITLE
chore: change manifests  0.11.2 -> 0.12.1

### DIFF
--- a/charms/kserve-controller/config.yaml
+++ b/charms/kserve-controller/config.yaml
@@ -23,6 +23,7 @@ options:
       configmap__logger : ''
       configmap__router : ''
       configmap__storageInitializer : ''
+      serving_runtimes__huggingfaceserver: ''
       serving_runtimes__lgbserver : ''
       serving_runtimes__kserve_mlserver : ''
       serving_runtimes__paddleserver : ''

--- a/charms/kserve-controller/metadata.yaml
+++ b/charms/kserve-controller/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   kserve-controller-image:
     type: oci-image
     description: OCI image for kserve controller
-    upstream-source: charmedkubeflow/kserve-controller:0.11.2-89c03a0
+    upstream-source: kserve/kserve-controller:v0.12.1
   kube-rbac-proxy-image:
     type: oci-image
     description: OCI image for kube rbac proxy

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -72,6 +72,7 @@ K8S_RESOURCE_FILES = [
     "src/templates/auth_manifests.yaml.j2",
     "src/templates/serving_runtimes_manifests.yaml.j2",
     "src/templates/webhook_manifests.yaml.j2",
+    "src/templates/cluster_storage_containers.yaml.j2",
 ]
 
 # Values for MinIO manifests https://kserve.github.io/website/0.11/modelserving/storage/s3/s3/

--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -1,20 +1,21 @@
 {
-    "configmap__agent": "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
-    "configmap__batcher": "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+    "configmap__agent": "kserve/agent:v0.12.1",
+    "configmap__batcher": "kserve/agent:v0.12.1",
     "configmap__explainers__alibi": "kserve/alibi-explainer:latest",
     "configmap__explainers__art": "kserve/art-explainer:latest",
-    "configmap__logger": "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
-    "configmap__router": "kserve/router:v0.11.1",
-    "configmap__storageInitializer": "charmedkubeflow/storage-initializer:0.11.2-1bda55b",
-    "serving_runtimes__lgbserver": "charmedkubeflow/lgbserver:0.11.2-1b3817e",
+    "configmap__logger": "kserve/agent:v0.12.1",
+    "configmap__router": "kserve/router:v0.12.1",
+    "configmap__storageInitializer": "kserve/storage-initializer:v0.12.1",
+    "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.12.1",
+    "serving_runtimes__lgbserver": "kserve/lgbserver:v0.12.1",
     "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.3.2",
-    "serving_runtimes__paddleserver": "charmedkubeflow/paddleserver:0.11.2-ee9909a",
-    "serving_runtimes__pmmlserver": "charmedkubeflow/pmmlserver:0.11.2-0a784c4",
-    "serving_runtimes__sklearnserver": "charmedkubeflow/sklearnserver:0.11.2-e54c69e",
+    "serving_runtimes__paddleserver": "kserve/paddleserver:v0.12.1",
+    "serving_runtimes__pmmlserver": "kserve/pmmlserver:v0.12.1",
+    "serving_runtimes__sklearnserver": "kserve/sklearnserver:v0.12.1",
     "serving_runtimes__tensorflow_serving": "tensorflow/serving:2.6.2",
-    "serving_runtimes__torchserve": "pytorch/torchserve-kfs:0.8.2",
+    "serving_runtimes__torchserve": "pytorch/torchserve-kfs:0.9.0",
     "serving_runtimes__tritonserver": "nvcr.io/nvidia/tritonserver:23.05-py3",
-    "serving_runtimes__xgbserver": "charmedkubeflow/xgbserver:0.11.2-d1246b8"
+    "serving_runtimes__xgbserver": "kserve/xgbserver:v0.12.1"
 }
 
 

--- a/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
+++ b/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterStorageContainer
+metadata:
+  name: default
+spec:
+  container:
+    image: {{ configmap__storageInitializer }}
+    name: storage-initializer
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+  supportedUriFormats:
+  - prefix: gs://
+  - prefix: s3://
+  - prefix: hdfs://
+  - prefix: webhdfs://
+  - regex: https://(.+?).blob.core.windows.net/(.+)
+  - regex: https://(.+?).file.core.windows.net/(.+)
+  - regex: https?://(.+)/(.+)

--- a/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
@@ -14,7 +14,9 @@ data:
         "memoryRequest": "1Gi",
         "memoryLimit": "1Gi",
         "cpuRequest": "1",
-        "cpuLimit": "1"
+        "cpuLimit": "1",
+        "maxBatchSize": "32",
+        "maxLatency": "5000"
     }
   credentials: |-
     {
@@ -31,6 +33,7 @@ data:
            "s3Region": "",
            "s3VerifySSL": "",
            "s3UseVirtualBucket": "",
+           "s3UseAccelerate": "",
            "s3UseAnonymousCredential": "",
            "s3CABundle": ""
        }
@@ -91,7 +94,12 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": false
+        "caBundleConfigMapName": "",
+        "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+        "enableDirectPvcVolumeMount": true,
+        "enableModelcar": false,
+        "cpuModelcar": "10m",
+        "memoryModelcar": "15Mi"
     }
 kind: ConfigMap
 metadata:

--- a/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
@@ -1,4 +1,3 @@
-# Source manifests/contrib/kserve/kserve/kserve.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -873,6 +872,19 @@ spec:
                           format: int32
                           type: integer
                       type: object
+                    resizePolicy:
+                      items:
+                        properties:
+                          resourceName:
+                            type: string
+                          restartPolicy:
+                            type: string
+                        required:
+                        - resourceName
+                        - restartPolicy
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     resources:
                       properties:
                         claims:
@@ -904,6 +916,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -2300,6 +2314,19 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  resizePolicy:
+                    items:
+                      properties:
+                        resourceName:
+                          type: string
+                        restartPolicy:
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   resources:
                     properties:
                       claims:
@@ -2331,6 +2358,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  restartPolicy:
+                    type: string
                   securityContext:
                     properties:
                       allowPrivilegeEscalation:
@@ -2941,6 +2970,10 @@ spec:
                         type: array
                     type: object
                 type: object
+              maxReplicas:
+                type: integer
+              minReplicas:
+                type: integer
               nodes:
                 additionalProperties:
                   properties:
@@ -3011,6 +3044,18 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              scaleMetric:
+                enum:
+                - cpu
+                - memory
+                - concurrency
+                - rps
+                type: string
+              scaleTarget:
+                type: integer
+              timeout:
+                format: int64
+                type: integer
             required:
             - nodes
             type: object
@@ -3871,6 +3916,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -3902,6 +3960,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -4491,6 +4551,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -4522,6 +4595,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -5125,6 +5200,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -5156,6 +5244,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -5783,6 +5873,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -5814,6 +5917,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -7740,6 +7845,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -7771,6 +7889,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -8003,6 +8123,633 @@ spec:
                     type: boolean
                   hostname:
                     type: string
+                  huggingface:
+                    properties:
+                      args:
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      image:
+                        type: string
+                      imagePullPolicy:
+                        type: string
+                      lifecycle:
+                        properties:
+                          postStart:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        properties:
+                          exec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            format: int32
+                            type: integer
+                          grpc:
+                            properties:
+                              port:
+                                format: int32
+                                type: integer
+                              service:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            properties:
+                              host:
+                                type: string
+                              httpHeaders:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                type: string
+                            type: object
+                          initialDelaySeconds:
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        type: string
+                      ports:
+                        items:
+                          properties:
+                            containerPort:
+                              format: int32
+                              type: integer
+                            hostIP:
+                              type: string
+                            hostPort:
+                              format: int32
+                              type: integer
+                            name:
+                              type: string
+                            protocol:
+                              default: TCP
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
+                      protocolVersion:
+                        type: string
+                      readinessProbe:
+                        properties:
+                          exec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            format: int32
+                            type: integer
+                          grpc:
+                            properties:
+                              port:
+                                format: int32
+                                type: integer
+                              service:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            properties:
+                              host:
+                                type: string
+                              httpHeaders:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                type: string
+                            type: object
+                          initialDelaySeconds:
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            type: integer
+                        type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      restartPolicy:
+                        type: string
+                      runtimeVersion:
+                        type: string
+                      securityContext:
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            properties:
+                              add:
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            type: boolean
+                          procMount:
+                            type: string
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            properties:
+                              level:
+                                type: string
+                              role:
+                                type: string
+                              type:
+                                type: string
+                              user:
+                                type: string
+                            type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        properties:
+                          exec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            format: int32
+                            type: integer
+                          grpc:
+                            properties:
+                              port:
+                                format: int32
+                                type: integer
+                              service:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            properties:
+                              host:
+                                type: string
+                              httpHeaders:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        type: boolean
+                      stdinOnce:
+                        type: boolean
+                      storage:
+                        properties:
+                          key:
+                            type: string
+                          parameters:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          path:
+                            type: string
+                          schemaPath:
+                            type: string
+                        type: object
+                      storageUri:
+                        type: string
+                      terminationMessagePath:
+                        type: string
+                      terminationMessagePolicy:
+                        type: string
+                      tty:
+                        type: boolean
+                      volumeDevices:
+                        items:
+                          properties:
+                            devicePath:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - devicePath
+                          - name
+                          type: object
+                        type: array
+                      volumeMounts:
+                        items:
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      workingDir:
+                        type: string
+                    type: object
                   imagePullSecrets:
                     items:
                       properties:
@@ -8398,6 +9145,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -8429,6 +9189,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -9000,6 +9762,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -9031,6 +9806,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -9636,6 +10413,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -9667,6 +10457,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtime:
                         type: string
                       runtimeVersion:
@@ -10257,6 +11049,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -10288,6 +11093,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -10882,6 +11689,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -10913,6 +11733,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -11494,6 +12316,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -11525,6 +12360,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -12113,6 +12950,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -12144,6 +12994,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -12852,6 +13704,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -12883,6 +13748,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -13466,6 +14333,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -13497,6 +14377,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -14156,6 +15038,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -14187,6 +15082,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -15479,6 +16376,19 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      resizePolicy:
+                        items:
+                          properties:
+                            resourceName:
+                              type: string
+                            restartPolicy:
+                              type: string
+                          required:
+                          - resourceName
+                          - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       resources:
                         properties:
                           claims:
@@ -15510,6 +16420,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             type: object
                         type: object
+                      restartPolicy:
+                        type: string
                       runtimeVersion:
                         type: string
                       securityContext:
@@ -16486,6 +17398,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -16517,6 +17442,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -17144,6 +18071,19 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        resizePolicy:
+                          items:
+                            properties:
+                              resourceName:
+                                type: string
+                              restartPolicy:
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         resources:
                           properties:
                             claims:
@@ -17175,6 +18115,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -18336,6 +19278,8 @@ spec:
                 properties:
                   CACerts:
                     type: string
+                  audience:
+                    type: string
                   name:
                     type: string
                   url:
@@ -18351,6 +19295,8 @@ spec:
                     address:
                       properties:
                         CACerts:
+                          type: string
+                        audience:
                           type: string
                         name:
                           type: string
@@ -19371,6 +20317,19 @@ spec:
                           format: int32
                           type: integer
                       type: object
+                    resizePolicy:
+                      items:
+                        properties:
+                          resourceName:
+                            type: string
+                          restartPolicy:
+                            type: string
+                        required:
+                        - resourceName
+                        - restartPolicy
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     resources:
                       properties:
                         claims:
@@ -19402,6 +20361,8 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    restartPolicy:
+                      type: string
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -20450,6 +21411,8 @@ spec:
               address:
                 properties:
                   CACerts:
+                    type: string
+                  audience:
                     type: string
                   name:
                     type: string

--- a/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
@@ -1,3 +1,4 @@
+# Source manifests/contrib/kserve/kserve/kserve.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2
@@ -9,7 +9,7 @@ spec:
   containers:
   - args:
     - --model_name= {{ '{{.Name}}' }}
-    image: {{ serving_runtimes__lgbserver }}
+    image: {{ serving_runtimes__huggingfaceserver }}
     name: kserve-container
     resources:
       limits:
@@ -91,7 +91,7 @@ spec:
   supportedModelFormats:
   - autoSelect: true
     name: sklearn
-    priority: 1
+    priority: 2
     version: "0"
   - autoSelect: true
     name: sklearn

--- a/charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/serving_runtimes_manifests.yaml.j2
@@ -1,6 +1,35 @@
 apiVersion: serving.kserve.io/v1alpha1
 kind: ClusterServingRuntime
 metadata:
+  name: kserve-huggingfaceserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name= {{ '{{.Name}}' }}
+    image: {{ serving_runtimes__lgbserver }}
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  protocolVersions:
+  - v2
+  - v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: huggingface
+    priority: 1
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
   name: kserve-lgbserver
 spec:
   annotations:
@@ -246,7 +275,7 @@ spec:
   protocolVersions:
   - v1
   - v2
-  - grpc-v1
+  - grpc-v2
   supportedModelFormats:
   - autoSelect: true
     name: pytorch

--- a/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
@@ -55,6 +55,7 @@ webhooks:
     matchExpressions:
     - key: serving.kserve.io/inferenceservice
       operator: Exists
+  reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
     - ""
@@ -62,7 +63,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+      "image" : "kserve/agent:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -12,7 +12,9 @@ batcher: |-
       "memoryRequest": "1Gi",
       "memoryLimit": "1Gi",
       "cpuRequest": "1",
-      "cpuLimit": "1"
+      "cpuLimit": "1",
+      "maxBatchSize": "32",
+      "maxLatency": "5000"
   }
 credentials: |-
   {
@@ -29,6 +31,7 @@ credentials: |-
          "s3Region": "",
          "s3VerifySSL": "",
          "s3UseVirtualBucket": "",
+         "s3UseAccelerate": "",
          "s3UseAnonymousCredential": "",
          "s3CABundle": ""
      }
@@ -60,7 +63,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+      "image" : "kserve/agent:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -74,7 +77,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.11.1",
+      "image" : "kserve/router:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -82,10 +85,15 @@ router: |-
   }
 storageInitializer: |-
   {
-      "image" : "charmedkubeflow/storage-initializer:0.11.2-1bda55b",
+      "image" : "kserve/storage-initializer:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
       "cpuLimit": "1",
-      "enableDirectPvcVolumeMount": false
+      "caBundleConfigMapName": "",
+      "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+      "enableDirectPvcVolumeMount": true,
+      "enableModelcar": false,
+      "cpuModelcar": "10m",
+      "memoryModelcar": "15Mi"
   }

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+      "image" : "kserve/agent:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -8,11 +8,13 @@ agent: |-
   }
 batcher: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+      "image" : "kserve/agent:v0.12.1",
       "memoryRequest": "1Gi",
       "memoryLimit": "1Gi",
       "cpuRequest": "1",
-      "cpuLimit": "1"
+      "cpuLimit": "1",
+      "maxBatchSize": "32",
+      "maxLatency": "5000"
   }
 credentials: |-
   {
@@ -29,6 +31,7 @@ credentials: |-
          "s3Region": "",
          "s3VerifySSL": "",
          "s3UseVirtualBucket": "",
+         "s3UseAccelerate": "",
          "s3UseAnonymousCredential": "",
          "s3CABundle": ""
      }
@@ -60,7 +63,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.11.2-f6cb212",
+      "image" : "kserve/agent:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -74,7 +77,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.11.1",
+      "image" : "kserve/router:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -82,10 +85,15 @@ router: |-
   }
 storageInitializer: |-
   {
-      "image" : "charmedkubeflow/storage-initializer:0.11.2-1bda55b",
+      "image" : "kserve/storage-initializer:v0.12.1",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
       "cpuLimit": "1",
-      "enableDirectPvcVolumeMount": false
+      "caBundleConfigMapName": "",
+      "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+      "enableDirectPvcVolumeMount": true,
+      "enableModelcar": false,
+      "cpuModelcar": "10m",
+      "memoryModelcar": "15Mi"
   }


### PR DESCRIPTION
closes: https://github.com/canonical/kserve-operators/issues/233
Changes from https://github.com/kubeflow/manifests. Comparing tags `v1.8.0` and `v1.9.0-rc.0`

Key changes: 
- added `huggungface` runtime 
- new `ClusterStorageContainer` `default` object
- few new `storageInitializer` config options

to not derail the task I have created [enhancement task](https://github.com/canonical/kserve-operators/issues/235) for the `huggingface` integration test.

