### PR TITLE
Update manifests for v0.13.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,6 +57,7 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           juju-channel: 3.5/stable
+          bootstrap-options: "--agent-version 3.5.0"
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
       - run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.25-strict/stable
+          channel: 1.26-strict/stable
           juju-channel: 3.5/stable
           bootstrap-options: "--agent-version 3.5.0"
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"

--- a/charms/kserve-controller/config.yaml
+++ b/charms/kserve-controller/config.yaml
@@ -18,7 +18,6 @@ options:
     default: | 
       configmap__agent : ''
       configmap__batcher : ''
-      configmap__explainers__alibi : ''
       configmap__explainers__art : ''
       configmap__logger : ''
       configmap__router : ''

--- a/charms/kserve-controller/metadata.yaml
+++ b/charms/kserve-controller/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   kserve-controller-image:
     type: oci-image
     description: OCI image for kserve controller
-    upstream-source: kserve/kserve-controller:v0.12.1
+    upstream-source: kserve/kserve-controller:v0.13.0
   kube-rbac-proxy-image:
     type: oci-image
     description: OCI image for kube rbac proxy

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -403,7 +403,6 @@ class KServeControllerCharm(CharmBase):
 
         # This are special cases comfigmap where they need to be split into image and version
         for image_name in [
-            "configmap__explainers__alibi",
             "configmap__explainers__art",
         ]:
             images[f"{image_name}__image"], images[f"{image_name}__version"] = images[

--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -1,21 +1,20 @@
 {
-    "configmap__agent": "kserve/agent:v0.12.1",
-    "configmap__batcher": "kserve/agent:v0.12.1",
-    "configmap__explainers__alibi": "kserve/alibi-explainer:latest",
+    "configmap__agent": "kserve/agent:v0.13.0",
+    "configmap__batcher": "kserve/agent:v0.13.0",
     "configmap__explainers__art": "kserve/art-explainer:latest",
-    "configmap__logger": "kserve/agent:v0.12.1",
-    "configmap__router": "kserve/router:v0.12.1",
-    "configmap__storageInitializer": "kserve/storage-initializer:v0.12.1",
-    "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.12.1",
-    "serving_runtimes__lgbserver": "kserve/lgbserver:v0.12.1",
+    "configmap__logger": "kserve/agent:v0.13.0",
+    "configmap__router": "kserve/router:v0.13.0",
+    "configmap__storageInitializer": "kserve/storage-initializer:v0.13.0",
+    "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.13.0",
+    "serving_runtimes__lgbserver": "kserve/lgbserver:v0.13.0",
     "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.3.2",
-    "serving_runtimes__paddleserver": "kserve/paddleserver:v0.12.1",
-    "serving_runtimes__pmmlserver": "kserve/pmmlserver:v0.12.1",
-    "serving_runtimes__sklearnserver": "kserve/sklearnserver:v0.12.1",
+    "serving_runtimes__paddleserver": "kserve/paddleserver:v0.13.0",
+    "serving_runtimes__pmmlserver": "kserve/pmmlserver:v0.13.0",
+    "serving_runtimes__sklearnserver": "kserve/sklearnserver:v0.13.0",
     "serving_runtimes__tensorflow_serving": "tensorflow/serving:2.6.2",
     "serving_runtimes__torchserve": "pytorch/torchserve-kfs:0.9.0",
     "serving_runtimes__tritonserver": "nvcr.io/nvidia/tritonserver:23.05-py3",
-    "serving_runtimes__xgbserver": "kserve/xgbserver:v0.12.1"
+    "serving_runtimes__xgbserver": "kserve/xgbserver:v0.13.0"
 }
 
 

--- a/charms/kserve-controller/src/templates/auth_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/auth_manifests.yaml.j2
@@ -95,9 +95,7 @@ rules:
   verbs:
   - create
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -134,18 +132,14 @@ rules:
   - create
   - delete
   - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/configmap_manifests.yaml.j2
@@ -44,10 +44,6 @@ data:
     }
   explainers: |-
     {
-        "alibi": {
-            "image" : "{{ configmap__explainers__alibi__image }}",
-            "defaultImageVersion": "{{ configmap__explainers__alibi__version }}"
-        },
         "art": {
             "image" : "{{ configmap__explainers__art__image }}",
             "defaultImageVersion": "{{ configmap__explainers__art__version }}"

--- a/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/crd_manifests.yaml.j2
@@ -3109,17 +3109,6 @@ metadata:
     app.kubernetes.io/name: kserve
   name: inferenceservices.serving.kserve.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: {{ cert }}
-        service:
-          name: kserve-webhook-server-service
-          namespace: kubeflow
-          path: /convert
-      conversionReviewVersions:
-      - v1beta1
   group: serving.kserve.io
   names:
     kind: InferenceService
@@ -3128,7 +3117,6 @@ spec:
     shortNames:
     - isvc
     singular: inferenceservice
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -3534,637 +3522,6 @@ spec:
                               type: object
                             type: array
                         type: object
-                    type: object
-                  alibi:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      config:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              default: TCP
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resizePolicy:
-                        items:
-                          properties:
-                            resourceName:
-                              type: string
-                            restartPolicy:
-                              type: string
-                          required:
-                          - resourceName
-                          - restartPolicy
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      resources:
-                        properties:
-                          claims:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      restartPolicy:
-                        type: string
-                      runtimeVersion:
-                        type: string
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      storage:
-                        properties:
-                          key:
-                            type: string
-                          parameters:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          path:
-                            type: string
-                          schemaPath:
-                            type: string
-                        type: object
-                      storageUri:
-                        type: string
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      type:
-                        type: string
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
                     type: object
                   annotations:
                     additionalProperties:
@@ -5434,6 +4791,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:
@@ -8079,6 +7454,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:
@@ -17632,6 +17025,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "kserve/agent:v0.12.1",
+      "image" : "kserve/agent:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -42,10 +42,6 @@ deploy: |-
   }
 explainers: |-
   {
-      "alibi": {
-          "image" : "custom",
-          "defaultImageVersion": "2.1"
-      },
       "art": {
           "image" : "kserve/art-explainer",
           "defaultImageVersion": "latest"
@@ -63,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "kserve/agent:v0.12.1",
+      "image" : "kserve/agent:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -77,7 +73,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.12.1",
+      "image" : "kserve/router:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -85,7 +81,7 @@ router: |-
   }
 storageInitializer: |-
   {
-      "image" : "kserve/storage-initializer:v0.12.1",
+      "image" : "kserve/storage-initializer:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "kserve/agent:v0.12.1",
+      "image" : "kserve/agent:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -8,7 +8,7 @@ agent: |-
   }
 batcher: |-
   {
-      "image" : "kserve/agent:v0.12.1",
+      "image" : "kserve/agent:v0.13.0",
       "memoryRequest": "1Gi",
       "memoryLimit": "1Gi",
       "cpuRequest": "1",
@@ -42,10 +42,6 @@ deploy: |-
   }
 explainers: |-
   {
-      "alibi": {
-          "image" : "kserve/alibi-explainer",
-          "defaultImageVersion": "latest"
-      },
       "art": {
           "image" : "kserve/art-explainer",
           "defaultImageVersion": "latest"
@@ -63,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "kserve/agent:v0.12.1",
+      "image" : "kserve/agent:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -77,7 +73,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.12.1",
+      "image" : "kserve/router:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -85,7 +81,7 @@ router: |-
   }
 storageInitializer: |-
   {
-      "image" : "kserve/storage-initializer:v0.12.1",
+      "image" : "kserve/storage-initializer:v0.13.0",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -448,7 +448,7 @@ async def test_configmap_changes_with_config(
     """
     await ops_test.model.applications["kserve-controller"].set_config(
         {
-            "custom_images": '{"configmap__batcher": "custom:1.0", "configmap__explainers__alibi": "custom:2.1"}'  # noqa: E501
+            "custom_images": '{"configmap__batcher": "custom:1.0"}'  # noqa: E501
         }
     )
     await ops_test.model.wait_for_idle(

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -447,9 +447,7 @@ async def test_configmap_changes_with_config(
         ops_test (OpsTest): The Juju OpsTest fixture to interact with the deployed model.
     """
     await ops_test.model.applications["kserve-controller"].set_config(
-        {
-            "custom_images": '{"configmap__batcher": "custom:1.0"}'  # noqa: E501
-        }
+        {"custom_images": '{"configmap__batcher": "custom:1.0"}'}  # noqa: E501
     )
     await ops_test.model.wait_for_idle(
         apps=["kserve-controller"], status="active", raise_on_blocked=True, timeout=300


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-operators/issues/238

Compared kustomize output for tags `v0.12.1` and `v0.13.0` for these upstream files https://github.com/kserve/kserve/tree/v0.13.0/config/overlays/kubeflow.

Changes: 
- Removing alibi server 
- Minor crd changes by adding deploymentStrategy
- Removing conversion webhook strategy
- Updating images