### PR TITLE
fix: configure proxy env vars storage init container

### DIFF
--- a/charms/kserve-controller/config.yaml
+++ b/charms/kserve-controller/config.yaml
@@ -35,4 +35,15 @@ options:
     description: >
       YAML or JSON formatted input defining images to use in Katib
       For usage details, see https://github.com/canonical/kserve-operators.
-
+  http-proxy:
+    default: ""
+    description: the value of HTTP_PROXY environment variable in the storage-initializer container.
+    type: string
+  https-proxy:
+    default: ""
+    description: the value of HTTPS_PROXY environment variable in the storage-initializer container.
+    type: string
+  no-proxy:
+    default: ""
+    description: the value of NO_PROXY environment variable in the storage-initializer container.
+    type: string

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -174,6 +174,9 @@ class KServeControllerCharm(CharmBase):
             "app_name": self.app.name,
             "namespace": self.model.name,
             "cert": f"'{ca_context.decode('utf-8')}'",
+            "http_proxy": self.model.config["http-proxy"],
+            "https_proxy": self.model.config["https-proxy"],
+            "no_proxy": self.model.config["no-proxy"],
         }
 
     @property

--- a/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
+++ b/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
@@ -13,6 +13,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    {% if http_proxy and https_proxy and no_proxy %}
+      env:
+      - name: HTTP_PROXY
+        value: {{ http_proxy }}
+      - name: HTTPS_PROXY
+        value: {{ https_proxy }}
+      - name: NO_PROXY
+        value: {{ no_proxy }}
+    {% endif %}
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
+++ b/charms/kserve-controller/src/templates/cluster_storage_containers.yaml.j2
@@ -13,15 +13,21 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
-    {% if http_proxy and https_proxy and no_proxy %}
-      env:
-      - name: HTTP_PROXY
-        value: {{ http_proxy }}
-      - name: HTTPS_PROXY
-        value: {{ https_proxy }}
-      - name: NO_PROXY
-        value: {{ no_proxy }}
-    {% endif %}
+  {% if http_proxy or https_proxy or no_proxy %}
+    env:
+  {% if http_proxy %}
+    - name: HTTP_PROXY
+      value: {{ http_proxy }}
+  {% endif %}
+  {% if https_proxy %}
+    - name: HTTPS_PROXY
+      value: {{ https_proxy }}
+  {% endif %}
+  {% if no_proxy %}
+    - name: NO_PROXY
+      value: {{ no_proxy }}
+  {% endif %}
+  {% endif %}
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://


### PR DESCRIPTION
part of https://github.com/canonical/knative-operators/issues/204

## Summary
Adds charm configs to `kserve-controller` charm to enable configuring the proxy environment variables in the `storage-initializer` init container of InferenceService Pod. It is done by modifying the `ClusterStorageContainer` CR, for more info see the [KServe docs](https://kserve.github.io/website/latest/modelserving/storage/storagecontainers/#create-the-clusterstoragecontainer-cr).


This change will enable CKF users to use KServe behind a proxy.

