### PR TITLE
(backport) Feat: Add Terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,6 +46,7 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: ./charms/kserve-controller
+      channel: 0.13/stable
       
   charm-integration:
     name: Individual Integration Tests

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -41,6 +41,12 @@ jobs:
     - run: sudo apt update && sudo apt install tox
     - run: tox -e ${{ matrix.charm }}-unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: ./charms/kserve-controller
+      
   charm-integration:
     name: Individual Integration Tests
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 build/
 .vscode
 .python-version
+venv/
+.terraform*
+*.tfstate*

--- a/charms/kserve-controller/terraform/README.md
+++ b/charms/kserve-controller/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for kserve-controller
+
+This is a Terraform module facilitating the deployment of the kserve-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kserve-controller" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kserve-controller" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/kserve-controller/terraform/main.tf
+++ b/charms/kserve-controller/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kserve_controller" {
+  charm {
+    name     = "kserve-controller"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/kserve-controller/terraform/outputs.tf
+++ b/charms/kserve-controller/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "app_name" {
+  value = juju_application.kserve_controller.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint = "metrics-endpoint"
+  }
+}
+
+output "requires" {
+  value = {
+    object_storage   = "object-storage",
+    ingress_gateway  = "ingress-gateway",
+    local_gateway    = "local-gateway",
+    secrets          = "secrets",
+    service_accounts = "service-accounts",
+    logging          = "logging",
+  }
+}

--- a/charms/kserve-controller/terraform/variables.tf
+++ b/charms/kserve-controller/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "0.13/stable"
 }
 
 variable "config" {

--- a/charms/kserve-controller/terraform/variables.tf
+++ b/charms/kserve-controller/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kserve-controller"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/kserve-controller/terraform/versions.tf
+++ b/charms/kserve-controller/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/kserve-controller/tox.ini
+++ b/charms/kserve-controller/tox.ini
@@ -71,6 +71,13 @@ commands =
         -m pytest --ignore={[vars]tst_path}integration -vv --tb native {posargs}
     coverage report
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:integration]
 description = Run integration tests
 deps =


### PR DESCRIPTION
Ref: #270 

This is a backport to create a Terraform module in the `terraform` directory. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit).

To test the module:
- Clone the repository and switch to this branch.
- First run `tox -e tflint` to ensure that linting is correct
- Change to the `terraform/` directory and run `terraform init`.
- Run `terraform apply -var "channel=0.13/stable" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.