### PR TITLE
Backport: Add alert rules to kserve-controller based on the KF093 spec (#265)

### DIFF
--- a/charms/kserve-controller/src/prometheus_alert_rules/KubeflowKserveControllerServices.rules
+++ b/charms/kserve-controller/src/prometheus_alert_rules/KubeflowKserveControllerServices.rules
@@ -1,0 +1,24 @@
+groups:
+- name: KubeflowKserveControllerServices
+  rules:
+  - alert: KubeflowServiceDown
+    expr: up{} < 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "{{ $labels.juju_charm }} service is Down ({{ $labels.juju_model }}/{{ $labels.juju_unit }})"
+      description: |
+       One or more targets of {{ $labels.juju_charm }} charm are down on unit {{ $labels.juju_model }}/{{ $labels.juju_unit }}.
+       LABELS = {{ $labels }}
+
+  - alert: KubeflowServiceIsNotStable
+    expr: avg_over_time(up{}[10m]) < 0.5
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ $labels.juju_charm }} service is not stable ({{ $labels.juju_model }}/{{ $labels.juju_unit }})"
+      description: |
+        {{ $labels.juju_charm }} unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} has been unreachable at least 50% of the time over the last 10 minutes.
+        LABELS = {{ $labels }}

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -16,9 +16,11 @@ import tenacity
 import yaml
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.testing import (
+    assert_alert_rules,
     assert_logging,
     assert_metrics_endpoint,
     deploy_and_assert_grafana_agent,
+    get_alert_rules,
 )
 from lightkube.core.exceptions import ApiError
 from lightkube.models.meta_v1 import ObjectMeta
@@ -337,6 +339,14 @@ async def test_metrics_enpoint(ops_test):
     """
     app = ops_test.model.applications[APP_NAME]
     await assert_metrics_endpoint(app, metrics_port=8080, metrics_path="/metrics")
+
+
+async def test_alert_rules(ops_test):
+    """Test check charm alert rules and rules defined in relation data bag."""
+    app = ops_test.model.applications[APP_NAME]
+    alert_rules = get_alert_rules()
+    logger.info("found alert_rules: %s", alert_rules)
+    await assert_alert_rules(app, alert_rules)
 
 
 #    # Remove the InferenceService deployed in RawDeployment mode


### PR DESCRIPTION
Part of: https://github.com/canonical/bundle-kubeflow/issues/1109

* Add alert rules to kserve-controller based on the KF093 spec
* add cos integration tests for alert rules