### PR TITLE
fix: integrate `kserve-agent` rock with patch

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -1,8 +1,8 @@
 {
-    "configmap__agent": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
-    "configmap__batcher": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+    "configmap__agent": "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
+    "configmap__batcher": "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
     "configmap__explainers__art": "kserve/art-explainer:latest",
-    "configmap__logger": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+    "configmap__logger": "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
     "configmap__router": "kserve/router:v0.13.0",
     "configmap__storageInitializer": "charmedkubeflow/storage-initializer:0.13.0-70e4564",
     "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.13.0",

--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -1,8 +1,8 @@
 {
-    "configmap__agent": "charmedkubeflow/kserve-agent:0.13.0-17792da",
-    "configmap__batcher": "charmedkubeflow/kserve-agent:0.13.0-17792da",
+    "configmap__agent": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+    "configmap__batcher": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
     "configmap__explainers__art": "kserve/art-explainer:latest",
-    "configmap__logger": "charmedkubeflow/kserve-agent:0.13.0-17792da",
+    "configmap__logger": "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
     "configmap__router": "kserve/router:v0.13.0",
     "configmap__storageInitializer": "charmedkubeflow/storage-initializer:0.13.0-70e4564",
     "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.13.0",

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.13.0-17792da",
+      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -59,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.13.0-17792da",
+      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+      "image" : "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -59,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+      "image" : "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+      "image" : "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -8,7 +8,7 @@ agent: |-
   }
 batcher: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+      "image" : "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
       "memoryRequest": "1Gi",
       "memoryLimit": "1Gi",
       "cpuRequest": "1",
@@ -59,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
+      "image" : "charmedkubeflow/kserve-agent:0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -1,6 +1,6 @@
 agent: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.13.0-17792da",
+      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",
@@ -8,7 +8,7 @@ agent: |-
   }
 batcher: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.13.0-17792da",
+      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
       "memoryRequest": "1Gi",
       "memoryLimit": "1Gi",
       "cpuRequest": "1",
@@ -59,7 +59,7 @@ ingress: |-
   }
 logger: |-
   {
-      "image" : "charmedkubeflow/kserve-agent:0.13.0-17792da",
+      "image" : "charmedkubeflow/kserve-agent:0.0.13.0-aba72fd",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",


### PR DESCRIPTION
closes https://github.com/canonical/kserve-rocks/issues/95

replaces the `kserve-agent` rock with the patch from https://github.com/canonical/kserve-rocks/pull/98