### PR TITLE
Remove rbac proxy layer

### DIFF
--- a/charms/kserve-controller/CONTRIBUTING.md
+++ b/charms/kserve-controller/CONTRIBUTING.md
@@ -57,8 +57,7 @@ juju add-model dev
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
 juju deploy ./kserve-controller_ubuntu-20.04-amd64.charm --trust \
-    --resource kserve-controller-image=$(yq '.resources."kserve-controller-image"."upstream-source"' metadata.yaml) \
-    --resource kube-rbac-proxy-image=$(yq '.resources."kube-rbac-proxy-image"."upstream-source"' metadata.yaml)
+    --resource kserve-controller-image=$(yq '.resources."kserve-controller-image"."upstream-source"' metadata.yaml)
 ```
 
 ## Canonical Contributor Agreement

--- a/charms/kserve-controller/README.md
+++ b/charms/kserve-controller/README.md
@@ -35,6 +35,6 @@ EOF
 juju deploy ./istio.yaml
 
 charmcraft pack
-juju deploy ./kserve-controller_ubuntu-20.04-amd64.charm --resource kserve-controller-image=kserve/kserve-controller:v0.8.0 --resource kube-rbac-proxy-image=gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0 --trust
+juju deploy ./kserve-controller_ubuntu-20.04-amd64.charm --resource kserve-controller-image=kserve/kserve-controller:v0.8.0 --trust
 
 

--- a/charms/kserve-controller/metadata.yaml
+++ b/charms/kserve-controller/metadata.yaml
@@ -12,17 +12,11 @@ summary: |
 containers:
   kserve-controller:
     resource: kserve-controller-image
-  kube-rbac-proxy:
-    resource: kube-rbac-proxy-image
 resources:
   kserve-controller-image:
     type: oci-image
     description: OCI image for kserve controller
     upstream-source: charmedkubeflow/kserve-controller:0.13.0-e151c86
-  kube-rbac-proxy-image:
-    type: oci-image
-    description: OCI image for kube rbac proxy
-    upstream-source: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -226,8 +226,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     resources = {
         "kserve-controller-image": METADATA["resources"]["kserve-controller-image"][
             "upstream-source"
-        ],
-        "kube-rbac-proxy-image": METADATA["resources"]["kube-rbac-proxy-image"]["upstream-source"],
+        ]
     }
     await ops_test.model.deploy(
         charm,


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-operators/issues/287

This PR removes the rbac proxy layer from the charm. This is possible as kubeflow-rbac-proxy was not intercepting the traffic.