### PR TITLE
Add huggingface integration test with bert

### DIFF
--- a/charms/kserve-controller/tests/integration/hugginface-bert.yaml
+++ b/charms/kserve-controller/tests/integration/hugginface-bert.yaml
@@ -1,0 +1,19 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: huggingface-bert
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: huggingface
+      args:
+        - --model_name=bert
+        - --model_id=google-bert/bert-base-uncased
+      resources:
+        limits:
+          cpu: 1
+          memory: 500Mi
+        requests:
+          cpu: 100m
+          memory: 250Mi

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -277,6 +277,7 @@ def test_namespace(lightkube_client: lightkube.Client):
         "./tests/integration/paddleserver-resnet.yaml",
         "./tests/integration/xgbserver.yaml",
         "./tests/integration/tensorflow-serving.yaml",
+        "./tests/integration/hugginface-bert.yaml"
     ],
 )
 def test_inference_service_raw_deployment(


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-operators/issues/235

This PR adds integration test for huggingface runtime with Bert. 