### PR TITLE
fix: replace kubernetes_manifests with resource_dispatcher library

### DIFF
--- a/charms/kserve-controller/lib/charms/resource_dispatcher/v0/resource_dispatcher.py
+++ b/charms/kserve-controller/lib/charms/resource_dispatcher/v0/resource_dispatcher.py
@@ -134,7 +134,7 @@ class KubernetesManifest:
 
     def __post_init__(self):
         """Validate that the manifest content is a valid YAML."""
-        self.manifest = yaml.safe_load(self.manifest_content)
+        self. manifest = yaml.safe_load(self.manifest_content)
 
 
 class KubernetesManifestsUpdatedEvent(RelationEvent):

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -31,7 +31,7 @@ from charms.istio_pilot.v0.istio_gateway_info import (
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.resource_dispatcher.v0.kubernetes_manifests import (
+from charms.resource_dispatcher.v0.resource_dispatcher import (
     KubernetesManifest,
     KubernetesManifestRequirerWrapper,
 )

--- a/charms/kserve-controller/tests/test_data/manifests.py
+++ b/charms/kserve-controller/tests/test_data/manifests.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from charms.resource_dispatcher.v0.kubernetes_manifests import KubernetesManifest
+from charms.resource_dispatcher.v0.resource_dispatcher import KubernetesManifest
 from pytest import param
 
 SECRETS_TEST_FILES = ["tests/test_data/secret.yaml.j2"]


### PR DESCRIPTION
The name of the library that is actually published in Charmhub is resource_dispatcher, not kubernetes_manifests. This mismatch was causing charmcraft fetch-lib to fail as it couldn't find the library under kubernetes_manifests. This commit brings the correct library by fetching it with charmcraft and replaces kubernetes_manifests where needed in the charm code.

Part of canonical/bundle-kubeflow#1209