### PR TITLE
fix: fetch kubernetes_manifests lib with charmcraft to match published lib

### DIFF
--- a/charms/kserve-controller/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
+++ b/charms/kserve-controller/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
@@ -108,7 +108,7 @@ from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEven
 logger = logging.getLogger(__name__)
 
 # The unique Charmhub library identifier, never change it
-LIBID = "372e7e90201741ba80006fc43fd81b49"
+LIBID = "4254ac012d3640ccbe0ac5380b2436c8"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
@@ -299,7 +299,7 @@ class KubernetesManifestRequirerWrapper(Object):
     ):
         self._charm = charm
         self._relation_name = relation_name
-    
+
     def _get_manifests_from_items(self, manifests_items: List[KubernetesManifest]):
         return [
             item.manifest for item in manifests_items
@@ -313,7 +313,7 @@ class KubernetesManifestRequirerWrapper(Object):
                 "leader.  Skipping event - no data sent."
             )
             return
-        
+
         manifests = self._get_manifests_from_items(manifest_items)
         relations = self._charm.model.relations.get(self._relation_name)
 
@@ -331,12 +331,12 @@ def get_name_of_breaking_app(relation_name: str) -> Optional[str]:
     If the application name is available, returns the name as a string;
     otherwise None.
     """
-    # In the case of a relation-broken event, Juju non-deterministically may or may not include 
-    # the breaking remote app's data in the relation data bag.  If this data is still in the data 
-    # bag, the `JUJU_REMOTE_APP` name will always be set.  For these cases, we return the 
+    # In the case of a relation-broken event, Juju non-deterministically may or may not include
+    # the breaking remote app's data in the relation data bag.  If this data is still in the data
+    # bag, the `JUJU_REMOTE_APP` name will always be set.  For these cases, we return the
     # remote app name so the caller can remove that app from the data bag before using it.
     #
-    # To catch these cases, we inspect the following environment variables managed by Juju: 
+    # To catch these cases, we inspect the following environment variables managed by Juju:
     #   JUJU_REMOTE_APP: the name of the app we are interacting with on this relation event
     #   JUJU_RELATION: the name of the relation we are interacting with on this relation event
     #   JUJU_HOOK_NAME: the name of the relation event, such as RELATION_NAME-relation-broken
@@ -350,5 +350,5 @@ def get_name_of_breaking_app(relation_name: str) -> Optional[str]:
     if not os.environ.get("JUJU_HOOK_NAME", None) == f"{relation_name}-relation-broken":
         # Not the relation-broken event
         return None
-    
+
     return os.environ.get("JUJU_REMOTE_APP", None)


### PR DESCRIPTION
This repository contained a version of the kubernetes_manifestss lib that was not exactly the one that was published in Charmhub. This caused issues when trying to fetch new versions of the library.

This commit replaces the offending file with the library that is actually published.

Part of canonical/bundle-kubeflow#1209