### PR TITLE
Integrate pmmlserver rock v0.14

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -9,7 +9,7 @@
     "serving_runtimes__lgbserver": "kserve/lgbserver:v0.14.1",
     "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.5.0",
     "serving_runtimes__paddleserver": "kserve/paddleserver:v0.14.1",
-    "serving_runtimes__pmmlserver": "kserve/pmmlserver:v0.14.1",
+    "serving_runtimes__pmmlserver": "charmedkubeflow/pmmlserver:0.14.1-bd08793",
     "serving_runtimes__sklearnserver": "kserve/sklearnserver:v0.14.1",
     "serving_runtimes__tensorflow_serving": "tensorflow/serving:2.6.2",
     "serving_runtimes__torchserve": "pytorch/torchserve-kfs:0.9.0",


### PR DESCRIPTION
This PR integrates the latest version of the pmmlserver rock, that was published in https://github.com/canonical/kserve-rocks/actions/runs/13261534027/job/37019834883