### PR TITLE
chore: bump version to 0.14.1-397d028

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -4,7 +4,7 @@
     "configmap__explainers__art": "kserve/art-explainer:latest",
     "configmap__logger": "kserve/agent:v0.14.1",
     "configmap__router": "kserve/router:v0.14.1",
-    "configmap__storageInitializer": "kserve/storage-initializer:v0.14.1",
+    "configmap__storageInitializer": "charmedkubeflow/storage-initializer:0.14.1-397d028",
     "serving_runtimes__huggingfaceserver": "kserve/huggingfaceserver:v0.14.1",
     "serving_runtimes__lgbserver": "kserve/lgbserver:v0.14.1",
     "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.5.0",

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -84,7 +84,7 @@ security: |-
   }
 storageInitializer: |-
   {
-      "image" : "kserve/storage-initializer:v0.14.1",
+      "image" : "charmedkubeflow/storage-initializer:0.14.1-397d028",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -84,7 +84,7 @@ security: |-
   }
 storageInitializer: |-
   {
-      "image" : "kserve/storage-initializer:v0.14.1",
+      "image" : "charmedkubeflow/storage-initializer:0.14.1-397d028",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",


### PR DESCRIPTION
closing [KF-6961](https://warthogs.atlassian.net/browse/KF-6961)

[KF-6961]: https://warthogs.atlassian.net/browse/KF-6961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ