### PR TITLE
fix: Add missing ClusterServingRuntime validation webhook

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -500,18 +500,6 @@ class KServeControllerCharm(CharmBase):
                 destination_path=CONTAINER_CERTS_DEST,
                 certs_store=self._stored,
             )
-            # update kserve-controller layer
-            update_layer(
-                self._controller_container_name,
-                self.controller_container,
-                self._controller_pebble_layer,
-                log,
-            )
-
-            # The kserve-controller service must be restarted whenever the
-            # configuration is changed, otherwise the service will remain
-            # unaware of such changes.
-            self._restart_controller_service()
 
             # If the Pod is not ready (condition with type Ready, all containers must be Ready)
             # then K8s will drop request to svc with message "connect: connection refused".
@@ -535,6 +523,19 @@ class KServeControllerCharm(CharmBase):
                         f"Unexpected ApiError happened: {e.status.message}",
                         BlockedStatus,
                     )
+
+            # update kserve-controller layer
+            update_layer(
+                self._controller_container_name,
+                self.controller_container,
+                self._controller_pebble_layer,
+                log,
+            )
+
+            # The kserve-controller service must be restarted whenever the
+            # configuration is changed, otherwise the service will remain
+            # unaware of such changes.
+            self._restart_controller_service()
         except ErrorWithStatus as err:
             self.model.unit.status = err.status
             log.error(f"Failed to handle {event} with error: {err}")

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -277,6 +277,7 @@ class KServeControllerCharm(CharmBase):
                     },
                 },
                 "checks": {
+                    # https://github.com/kserve/kserve/blob/v0.14.1/install/v0.14.1/kserve_kubeflow.yaml#L32000
                     "kserve-controller-ready": {
                         "override": "replace",
                         "level": "ready",
@@ -285,6 +286,7 @@ class KServeControllerCharm(CharmBase):
                         "threshold": 3,
                         "http": {"url": "http://localhost:8081/readyz"},
                     },
+                    # https://github.com/kserve/kserve/blob/v0.14.1/install/v0.14.1/kserve_kubeflow.yaml#L31988
                     "kserve-controller-alive": {
                         "override": "replace",
                         "level": "alive",

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -531,8 +531,9 @@ class KServeControllerCharm(CharmBase):
                 log.info("KServe Controller Pod was ready. Applied all ClusterServingRuntimes.")
             except ApiError as e:
                 if "connection refused" in e.status.message:
+                    log.warning("Failed to create ClusterServingRuntimes: %s", e.status.message)
                     msg = "Charm Pod is not ready yet. Will apply ClusterServingRuntimes later."
-                    log.warning(msg)
+                    log.info(msg)
                     self.model.unit.status = MaintenanceStatus(msg)
                 else:
                     log.warning("Unexpected ApiError happened: %s", e)

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -270,6 +270,10 @@ class KServeControllerCharm(CharmBase):
                             "POD_NAMESPACE": self.model.name,
                             "SECRET_NAME": "kserve-webhook-server-cert",
                         },
+                        "on-check-failure": {
+                            "kserve-controller-ready": "restart",
+                            "kserve-controller-alive": "restart",
+                        },
                     },
                 },
                 "checks": {

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -281,18 +281,12 @@ class KServeControllerCharm(CharmBase):
                     "kserve-controller-ready": {
                         "override": "replace",
                         "level": "ready",
-                        "period": "5m",
-                        "timeout": "60s",
-                        "threshold": 3,
                         "http": {"url": "http://localhost:8081/readyz"},
                     },
                     # https://github.com/kserve/kserve/blob/v0.14.1/install/v0.14.1/kserve_kubeflow.yaml#L31988
                     "kserve-controller-alive": {
                         "override": "replace",
                         "level": "alive",
-                        "period": "5m",
-                        "timeout": "60s",
-                        "threshold": 3,
                         "http": {"url": "http://localhost:8081/healthz"},
                     },
                 },

--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -16,6 +16,3 @@
     "serving_runtimes__tritonserver": "nvcr.io/nvidia/tritonserver:23.05-py3",
     "serving_runtimes__xgbserver": "charmedkubeflow/xgbserver:0.14.1-77c46bc"
 }
-
-
-

--- a/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
@@ -209,4 +209,3 @@ webhooks:
     resources:
     - clusterservingruntimes
   sideEffects: None
----

--- a/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
+++ b/charms/kserve-controller/src/templates/webhook_manifests.yaml.j2
@@ -181,3 +181,32 @@ webhooks:
     resources:
     - trainedmodels
   sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: clusterservingruntime.serving.kserve.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: {{ cert }}
+    service:
+      name: kserve-webhook-server-service
+      namespace: {{ namespace }}
+      path: /validate-serving-kserve-io-v1alpha1-clusterservingruntime
+  failurePolicy: Fail
+  name: clusterservingruntime.kserve-webhook-server.validator
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterservingruntimes
+  sideEffects: None
+---

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -30,6 +30,10 @@ KSERVE_CONTROLLER_EXPECTED_LAYER = {
             "override": "replace",
             "startup": "enabled",
             "summary": "KServe Controller",
+            "on-check-failure": {
+                "kserve-controller-ready": "restart",
+                "kserve-controller-alive": "restart",
+            },
         }
     },
     "checks": {

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -40,17 +40,11 @@ KSERVE_CONTROLLER_EXPECTED_LAYER = {
         "kserve-controller-ready": {
             "override": "replace",
             "level": "ready",
-            "period": "5m",
-            "timeout": "60s",
-            "threshold": 3,
             "http": {"url": "http://localhost:8081/readyz"},
         },
         "kserve-controller-alive": {
             "override": "replace",
             "level": "alive",
-            "period": "5m",
-            "timeout": "60s",
-            "threshold": 3,
             "http": {"url": "http://localhost:8081/healthz"},
         },
     },

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -23,12 +23,33 @@ KSERVE_CONTROLLER_EXPECTED_LAYER = {
     "services": {
         "kserve-controller": {
             "command": "/manager --metrics-addr=:8080",
-            "environment": {"POD_NAMESPACE": None, "SECRET_NAME": "kserve-webhook-server-cert"},
+            "environment": {
+                "POD_NAMESPACE": None,
+                "SECRET_NAME": "kserve-webhook-server-cert",
+            },
             "override": "replace",
             "startup": "enabled",
             "summary": "KServe Controller",
         }
-    }
+    },
+    "checks": {
+        "kserve-controller-ready": {
+            "override": "replace",
+            "level": "ready",
+            "period": "5m",
+            "timeout": "60s",
+            "threshold": 3,
+            "http": {"url": "http://localhost:8081/readyz"},
+        },
+        "kserve-controller-alive": {
+            "override": "replace",
+            "level": "alive",
+            "period": "5m",
+            "timeout": "60s",
+            "threshold": 3,
+            "http": {"url": "http://localhost:8081/healthz"},
+        },
+    },
 }
 
 
@@ -94,7 +115,9 @@ def test_metrics(harness):
             port=8080, targetPort=8080, name="kserve-controller-metrics"
         )
         mock_service_patcher.assert_called_once_with(
-            harness.charm, [mock_service_port.return_value], service_name="kserve-controller"
+            harness.charm,
+            [mock_service_port.return_value],
+            service_name="kserve-controller",
         )
 
 
@@ -125,6 +148,7 @@ def test_on_install_active(harness, mocked_resource_handler):
     harness.begin()
     harness.charm._k8s_resource_handler = mocked_resource_handler
     harness.charm._cm_resource_handler = mocked_resource_handler
+    harness.charm._cluster_runtimes_resource_handler = mocked_resource_handler
     harness.charm.on.install.emit()
     mocked_resource_handler.apply.assert_called()
     assert harness.charm.model.unit.status == ActiveStatus()
@@ -136,6 +160,7 @@ def test_on_install_exception(harness, mocked_resource_handler, mocker):
     mocked_resource_handler.apply.side_effect = _FakeApiError()
     harness.charm._k8s_resource_handler = mocked_resource_handler
     harness.charm._cm_resource_handler = mocked_resource_handler
+    harness.charm._cluster_runtimes_resource_handler = mocked_resource_handler
     with pytest.raises(ApiError):
         harness.charm.on.install.emit()
     mocked_logger.error.assert_called()
@@ -202,6 +227,7 @@ def test_on_remove_success(harness, mocker, mocked_resource_handler):
     harness.begin()
     harness.charm._k8s_resource_handler = mocked_resource_handler
     harness.charm._cm_resource_handler = mocked_resource_handler
+    harness.charm._cluster_runtimes_resource_handler = mocked_resource_handler
     harness.charm.on.remove.emit()
     mocked_delete_many.assert_called()
     assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
@@ -216,6 +242,7 @@ def test_on_remove_failure(harness, mocker, mocked_resource_handler):
 
     harness.charm._k8s_resource_handler = mocked_resource_handler
     harness.charm._cm_resource_handler = mocked_resource_handler
+    harness.charm._cluster_runtimes_resource_handler = mocked_resource_handler
 
     with pytest.raises(ApiError):
         harness.charm.on.remove.emit()
@@ -261,7 +288,8 @@ def test_generate_gateways_context_serverless_no_relation(
 
 
 @pytest.mark.parametrize(
-    "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
+    "remote_data",
+    ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"}),
 )
 def test_generate_gateways_context_raw_mode_missing_data(
     remote_data, harness, mocker, mocked_resource_handler
@@ -281,7 +309,8 @@ def test_generate_gateways_context_raw_mode_missing_data(
 
 
 @pytest.mark.parametrize(
-    "remote_data", ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"})
+    "remote_data",
+    ({"gateway_name": "test-name"}, {"gateway_namespace": "test-namespace"}),
 )
 @patch("charm.KServeControllerCharm._restart_controller_service")
 def test_generate_gateways_context_serverless_missing_data(


### PR DESCRIPTION
Closes https://github.com/canonical/kserve-operators/issues/301

## Changes
1. Adds pebble readiness and liveness probes for KServe Controller (workload service)
2. Creates a separate resource handler for applying `ClusterServingRuntimes` separately
3. Gracefully handles `connection refused` errors, when applying the `ClusterServingRuntimes`
## Review Notes
- I noticed that we don't handle the `update-status` event at all in the KServe controller
- In `kfp-api` we have a [dedicated handler](https://github.com/canonical/kfp-operators/blob/53b7e82f2625c17af994f124aefc229c2dd7f9ee/charms/kfp-api/src/charm.py#L108) for `update-status` that [checks the probes status](https://github.com/canonical/kfp-operators/blob/53b7e82f2625c17af994f124aefc229c2dd7f9ee/charms/kfp-api/src/charm.py#L314-L332)
    - I didn't add it as the integration tests were failing, because the `update-status-hook-interval` was getting set to 10s. Then manifests kept being applied and the controller never got to active status