### PR TITLE
chore: integrate charmedkubeflow/tensorflow-serving:2.6.2-3f1565f rock

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -11,7 +11,7 @@
     "serving_runtimes__paddleserver": "kserve/paddleserver:v0.14.1",
     "serving_runtimes__pmmlserver": "charmedkubeflow/pmmlserver:0.14.1-bd08793",
     "serving_runtimes__sklearnserver": "charmedkubeflow/sklearnserver:0.14.1-685a8e7",
-    "serving_runtimes__tensorflow_serving": "tensorflow/serving:2.6.2",
+    "serving_runtimes__tensorflow_serving": "charmedkubeflow/tensorflow-serving:2.6.2-3f1565f",
     "serving_runtimes__torchserve": "pytorch/torchserve-kfs:0.9.0",
     "serving_runtimes__tritonserver": "nvcr.io/nvidia/tritonserver:23.05-py3",
     "serving_runtimes__xgbserver": "charmedkubeflow/xgbserver:0.14.1-77c46bc"


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/113