### PR TITLE
fix: handle validating webhook unreachable errors

### DIFF
--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -46,6 +46,7 @@ from ops.model import (
     ActiveStatus,
     BlockedStatus,
     Container,
+    ErrorStatus,
     MaintenanceStatus,
     ModelError,
     WaitingStatus,
@@ -555,7 +556,7 @@ class KServeControllerCharm(CharmBase):
                     log.warning("Unexpected ApiError happened: %s", e)
                     raise ErrorWithStatus(
                         f"Unexpected ApiError happened: {e.status.message}",
-                        BlockedStatus,
+                        ErrorStatus,
                     )
         except ErrorWithStatus as err:
             self.model.unit.status = err.status

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -141,6 +141,7 @@ class KServeControllerCharm(CharmBase):
             self.on.config_changed,
             self.on.kserve_controller_pebble_ready,
             self.on.leader_elected,
+            self.on.update_status,
             self.on["local-gateway"].relation_changed,
             self.on["ingress-gateway"].relation_changed,
             self.on["object-storage"].relation_changed,
@@ -515,29 +516,37 @@ class KServeControllerCharm(CharmBase):
                 log,
             )
 
+            # The kserve-controller service must be restarted whenever the
+            # configuration is changed, otherwise the service will remain
+            # unaware of such changes.
+            self._restart_controller_service()
 
+            # FIXME: This block sets the charm to Maintenance and relies on update status hook
+            # to retrigger the reconciliation. We can replace this with Pebble Notices, or Pebble
+            # Checks once https://github.com/canonical/pebble/issues/164 is resolved.
             try:
                 self.cluster_runtimes_resource_handler.apply()
                 self.model.unit.status = ActiveStatus()
                 log.info("KServe Controller Pod was ready. Applied all ClusterServingRuntimes.")
             except ApiError as e:
+                # If the Pod is not ready (condition with type Ready, all containers must be Ready)
+                # then K8s will drop request to svc with message "connect: connection refused".
+                # The charm container will become ready only once the start event has completed,
+                # and the workload container's pebble readiness probes are healthy.
+                # Until then the Pod is not ready, non-ready containers, thus traffic will
+                # be dropped.
+                # https://github.com/canonical/kserve-operators/issues/301
                 if "connection refused" in e.status.message:
-                    # If the Pod is not ready (condition with type Ready, all containers must be Ready)
-                    # then K8s will drop request to svc with message "connect: connection refused".
-                    # The charm container will become ready only once the start event has completed, and
-                    # the workload container's pebble readiness probes are healthy.
-                    # Until then the Pod is not ready, non-ready containers, thus traffic will be dropped.
-                    # https://github.com/canonical/kserve-operators/issues/301
                     log.warning("Failed to create ClusterServingRuntimes: %s", e.status.message)
                     msg = "Charm Pod is not ready yet. Will apply ClusterServingRuntimes later."
                     log.info(msg)
                     self.model.unit.status = MaintenanceStatus(msg)
+                # If the Endpoint for the webhook server Service is not yet created
+                # then K8s will drop request to svc with message "no endpoints available".
+                # The Endpoint gets created automatically by the control plane shortly
+                # after the Service is created. Drop the traffic and set the status to
+                # `MaintenanceStatus` expecting the error to be resolved in the future hooks.
                 elif "no endpoints available" in e.status.message:
-                    # If the Endpoint for the webhook server Service is not yet created
-                    # then K8s will drop request to svc with message "no endpoints available".
-                    # The Endpoint gets created automatically by the control plane shortly
-                    # after the Service is created. Drop the traffic and set the status to
-                    # `MaintenanceStatus` expecting the error to be resolved in the future hooks.
                     log.warning("Failed to create ClusterServingRuntimes: %s", e.status.message)
                     msg = "Service Endpoints are not yet created. Will apply ClusterServingRuntimes later."
                     log.info(msg)
@@ -548,11 +557,6 @@ class KServeControllerCharm(CharmBase):
                         f"Unexpected ApiError happened: {e.status.message}",
                         BlockedStatus,
                     )
-
-            # The kserve-controller service must be restarted whenever the
-            # configuration is changed, otherwise the service will remain
-            # unaware of such changes.
-            self._restart_controller_service()
         except ErrorWithStatus as err:
             self.model.unit.status = err.status
             log.error(f"Failed to handle {event} with error: {err}")

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -547,6 +547,7 @@ class KServeControllerCharm(CharmBase):
                 # The Endpoint gets created automatically by the control plane shortly
                 # after the Service is created. Drop the traffic and set the status to
                 # `MaintenanceStatus` expecting the error to be resolved in the future hooks.
+                # https://github.com/canonical/kserve-operators/issues/321
                 elif "no endpoints available" in e.status.message:
                     log.warning("Failed to create ClusterServingRuntimes: %s", e.status.message)
                     msg = "Webhook Server Service endpoints not ready. Will apply ClusterServingRuntimes later."

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -549,7 +549,7 @@ class KServeControllerCharm(CharmBase):
                 # `MaintenanceStatus` expecting the error to be resolved in the future hooks.
                 elif "no endpoints available" in e.status.message:
                     log.warning("Failed to create ClusterServingRuntimes: %s", e.status.message)
-                    msg = "Service Endpoints are not yet created. Will apply ClusterServingRuntimes later."
+                    msg = "Webhook Server Service endpoints not ready. Will apply ClusterServingRuntimes later."
                     log.info(msg)
                     self.model.unit.status = MaintenanceStatus(msg)
                 else:

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -238,7 +238,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.integrate("istio-pilot", APP_NAME)
 
     # issuing dummy update_status just to trigger an event
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(fast_interval="60s"):
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",


### PR DESCRIPTION
Closes #321 #319

## Summary
Handles applying the `ClusterServingRuntime` (CSR) resources errors by:
1. Moving starting the pebble service (i.e. calling `update_layer` for the first time) to run before attempting to apply the CSRs, this is essential for the kserve controller to be up which serves the webhook
2. Putting the charm to Maintenance and skip applying the CSRs on the known error messages that are expected during startup, this includes `connection refused` and `no endpoints available` errors.
3. Observing the `update_status` event so that it triggers the charm reconciliation after the update status interval, the webhook server should be up by then.

## Testing
1. Deploy `latest/edge` bundle on AKS [guide](https://charmed-kubeflow.io/docs/install-on-aks)
4. `kserve-controller` charm goes to Blocked
5. Refresh to the charm from this PR:
```
juju deploy kserve-controller --trust --channel=latest/edge/pr-322 --base ubuntu@20.04
```
6. Make sure the charm goes to `active`
7. Check the debug logs to see the log from when the erros were caught and when `ClusterServingRuntimes` were applied