### PR TITLE
Integrate router rock

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -3,7 +3,7 @@
     "configmap__batcher": "charmedkubeflow/kserve-agent:0.14.1-0fb8a34",
     "configmap__explainers__art": "charmedkubeflow/artexplainer:0.14.1-8ace842",
     "configmap__logger": "charmedkubeflow/kserve-agent:0.14.1-0fb8a34",
-    "configmap__router": "kserve/router:v0.14.1",
+    "configmap__router": "charmedkubeflow/kserve-router:0.14.1-35ac068",
     "configmap__storageInitializer": "charmedkubeflow/storage-initializer:0.14.1-397d028",
     "serving_runtimes__huggingfaceserver": "charmedkubeflow/huggingfaceserver:0.14.1-790009b",
     "serving_runtimes__lgbserver": "charmedkubeflow/lgbserver:0.14.1-537653b",

--- a/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data-changed.yaml
@@ -72,7 +72,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.14.1",
+      "image" : "charmedkubeflow/kserve-router:0.14.1-35ac068",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",

--- a/charms/kserve-controller/tests/integration/config-map-data.yaml
+++ b/charms/kserve-controller/tests/integration/config-map-data.yaml
@@ -72,7 +72,7 @@ metricsAggregator: |-
   }
 router: |-
   {
-      "image" : "kserve/router:v0.14.1",
+      "image" : "charmedkubeflow/kserve-router:0.14.1-35ac068",
       "memoryRequest": "100Mi",
       "memoryLimit": "1Gi",
       "cpuRequest": "100m",


### PR DESCRIPTION
Closes #326 

This PR updates `default-custom-images.json` in the `kserver-controller` charm from the upstream image to the new router rock.

Note that the config maps in `charms/kserve-controller/tests/integration` are also updated