### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/charms/kserve-controller/requirements-integration.txt
+++ b/charms/kserve-controller/requirements-integration.txt
@@ -38,7 +38,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -67,7 +67,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/kserve-controller/tests/integration/charms_dependencies.py
+++ b/charms/kserve-controller/tests/integration/charms_dependencies.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Canonical Ltd.
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
+KNATIVE_OPERATOR = CharmSpec(charm="knative-operator", channel="latest/edge", trust=True)
+KNATIVE_SERVING = CharmSpec(charm="knative-serving", channel="latest/edge", trust=True)
+METACONTROLLER_OPERATOR = CharmSpec(
+    charm="metacontroller-operator", channel="latest/edge", trust=True
+)
+MINIO = CharmSpec(
+    charm="minio",
+    channel="latest/edge",
+    trust=True,
+    config={"access-key": "minio", "secret-key": "minio-secret-key"},
+)
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
