### PR TITLE
fix: Remove namespace config from `knative-serving` in integration tests

### DIFF
--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -424,7 +424,6 @@ async def test_deploy_knative_dependencies(ops_test: OpsTest):
         KNATIVE_SERVING.charm,
         channel=KNATIVE_SERVING.channel,
         config={
-            "namespace": "knative-serving",
             "istio.gateway.namespace": namespace,
             "istio.gateway.name": ISTIO_INGRESS_GATEWAY,
         },


### PR DESCRIPTION
Closes #379 

This PR simply removes the `namespace` config option when deploying `knative-serving` in the integration tests. This follows the removal of the option in https://github.com/canonical/knative-operators/pull/356