### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,5 +27,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: "24.04"
           tag-prefix: ${{ github.event.inputs.charm-name }}
           charm-path: charms/${{ github.event.inputs.charm-name}}

--- a/charms/kserve-controller/terraform/README.md
+++ b/charms/kserve-controller/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/kserve-controller/terraform/main.tf
+++ b/charms/kserve-controller/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kserve_controller" {
   charm {
     name     = "kserve-controller"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/kserve-controller/terraform/variables.tf
+++ b/charms/kserve-controller/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kserve-controller"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR is a backport of #399.