### PR TITLE
fix: add integration test for predictionserver

### DIFF
--- a/charms/kserve-controller/tests/integration/crs/predictionserver-sklearn.yaml
+++ b/charms/kserve-controller/tests/integration/crs/predictionserver-sklearn.yaml
@@ -1,0 +1,19 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "predictionserver-sklearn-iris"
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      protocolVersion: v2
+      runtime: kserve-predictiveserver
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
+      resources:
+        limits:
+          cpu: 1
+          memory: 500Mi
+        requests:
+          cpu: 100m
+          memory: 250Mi

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -195,13 +195,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
 @pytest.mark.parametrize(
     "inference_file",
     [
+        YAMLS_PREFIX + "predictionserver-sklearn.yaml",
         YAMLS_PREFIX + "sklearn-iris.yaml",
         YAMLS_PREFIX + "lgbserver.yaml",
         YAMLS_PREFIX + "pmml-server.yaml",
         YAMLS_PREFIX + "paddleserver-resnet.yaml",
         YAMLS_PREFIX + "xgbserver.yaml",
         YAMLS_PREFIX + "tensorflow-serving.yaml",
-        YAMLS_PREFIX + "predictionserver-sklearn.yaml",
     ],
 )
 def test_inference_service(

--- a/charms/kserve-controller/tests/integration/test_charm.py
+++ b/charms/kserve-controller/tests/integration/test_charm.py
@@ -201,6 +201,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         YAMLS_PREFIX + "paddleserver-resnet.yaml",
         YAMLS_PREFIX + "xgbserver.yaml",
         YAMLS_PREFIX + "tensorflow-serving.yaml",
+        YAMLS_PREFIX + "predictionserver-sklearn.yaml",
     ],
 )
 def test_inference_service(

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -134,6 +134,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 @pytest.mark.parametrize(
     "inference_file",
     [
+        YAMLS_PREFIX + "predictionserver-sklearn.yaml",
         YAMLS_PREFIX + "sklearn-iris.yaml",
         YAMLS_PREFIX + "lgbserver.yaml",
         YAMLS_PREFIX + "pmml-server.yaml",


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-operators/issues/433