### PR TITLE
fix: adding backwards compatibility logic for `deployment_mode` config option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,17 +8,6 @@ on:
         required: true
 
 jobs:
-  lib-check:
-    name: Check libraries
-    strategy:
-      matrix:
-        charm:
-        - kserve-controller
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: ./charms/${{ matrix.charm }}
-
   lint:
     name: Lint Code
     runs-on: ubuntu-24.04

--- a/charms/kserve-controller/config.yaml
+++ b/charms/kserve-controller/config.yaml
@@ -3,7 +3,7 @@
 options:
   deployment-mode:
     default: "knative"
-    description: Deployment mode for kserve. It can only be Standard or Knative, and the latter requires knative-serving to be present in the model, and the local-gateway relation to be established.
+    description: Deployment mode for kserve. It can only be Standard or Knative, and the latter requires knative-serving to be present in the model, and the local-gateway relation to be established. Although deprecated, "Serverless" and "RawDeployment" can still be used although it is discouraged.
     type: string
   domain-name:
     default: "example.com"

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -214,12 +214,12 @@ class KServeControllerCharm(CharmBase):
         """Returns the deployment mode."""
         _mode = str(self.model.config["deployment-mode"]).lower()
         if _mode == "rawdeployment":
-            log.warn(
+            log.warning(
                 "Usage of deployment_mode=RawDeployment is deprecated. Please consider to switch to use 'deployment_mode=standard'"
             )
             return "standard"
         if _mode == "serverless":
-            log.warn(
+            log.warning(
                 "Usage of deployment_mode=Serverless is deprecated. Please consider to switch to use 'deployment_mode=knative'"
             )
             return "knative"

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -213,11 +213,15 @@ class KServeControllerCharm(CharmBase):
     def _deployment_mode(self) -> str:
         """Returns the deployment mode."""
         _mode = str(self.model.config["deployment-mode"]).lower()
-        if "rawdeployment":
-            log.warn("Usage of deployment_mode=RawDeployment is deprecated. Please consider to switch to use 'deployment_mode=standard'") 
+        if _mode == "rawdeployment":
+            log.warn(
+                "Usage of deployment_mode=RawDeployment is deprecated. Please consider to switch to use 'deployment_mode=standard'"
+            )
             return "standard"
         if _mode == "serverless":
-            log.warn("Usage of deployment_mode=Serverless is deprecated. Please consider to switch to use 'deployment_mode=knative'")
+            log.warn(
+                "Usage of deployment_mode=Serverless is deprecated. Please consider to switch to use 'deployment_mode=knative'"
+            )
             return "knative"
         return _mode
 

--- a/charms/kserve-controller/src/charm.py
+++ b/charms/kserve-controller/src/charm.py
@@ -212,7 +212,14 @@ class KServeControllerCharm(CharmBase):
     @property
     def _deployment_mode(self) -> str:
         """Returns the deployment mode."""
-        return str(self.model.config["deployment-mode"]).lower()
+        _mode = str(self.model.config["deployment-mode"]).lower()
+        if "rawdeployment":
+            log.warn("Usage of deployment_mode=RawDeployment is deprecated. Please consider to switch to use 'deployment_mode=standard'") 
+            return "standard"
+        if _mode == "serverless":
+            log.warn("Usage of deployment_mode=Serverless is deprecated. Please consider to switch to use 'deployment_mode=knative'")
+            return "knative"
+        return _mode
 
     @property
     def _is_standard_mode(self) -> bool:

--- a/charms/kserve-controller/tests/unit/test_charm.py
+++ b/charms/kserve-controller/tests/unit/test_charm.py
@@ -756,3 +756,58 @@ def test_generate_gateways_context_standard_mode(
     assert gateway_context["ingress_gateway_name"] == "test-gateway"
     assert gateway_context["ingress_gateway_namespace"] == "test-namespace"
     assert gateway_context["ingress_gateway_service_name"] == "test-deployment"
+
+
+@pytest.mark.parametrize(
+    "deployment_mode, expected_status",
+    [
+        (
+            "Standard",
+            ActiveStatus(),
+        ),
+        (
+            "Knative",
+            ActiveStatus(),
+        ),
+        (
+            "RawDeployment",
+            ActiveStatus(),
+        ),
+        (
+            "Serverless",
+            ActiveStatus(),
+        ),
+        (
+            "NotAllowed",
+            BlockedStatus("Please set deployment-mode to either Knative or Standard"),
+        ),
+    ],
+)
+def test_deployment_modes_values(
+    mocked_resource_handler,
+    mocker,
+    harness: Harness,
+    deployment_mode: str,
+    expected_status: StatusBase,
+):
+    harness.begin()
+    harness.charm._k8s_resource_handler = mocked_resource_handler
+
+    relation_id_ingress = harness.add_relation("ingress-gateway", "istio-pilot")
+    relation_id_local = harness.add_relation("local-gateway", "test-knative-serving")
+
+    # Updated the data bag with ingress-gateway
+    remote_ingress_data = {
+        "gateway_name": "test-ingress-name",
+        "gateway_namespace": "test-ingress-namespace",
+    }
+    remote_local_data = {
+        "gateway_name": "test-local-name",
+        "gateway_namespace": "test-local-namespace",
+    }
+    harness.update_relation_data(relation_id_ingress, "istio-pilot", remote_ingress_data)
+    harness.update_relation_data(relation_id_local, "test-knative-serving", remote_local_data)
+
+    harness.update_config({"deployment-mode": deployment_mode})
+
+    assert harness.charm.model.unit.status == expected_status


### PR DESCRIPTION
PR #424 has slightly broken backwards compatibility since it uses new config options value. This PR restores the backwards compatibility by adding support to remapping the config value. 

We should keep the logic in for at least an intermediate release and suggest to people to swap from one to another, to then remove the support for the old values. 