### PR TITLE
chore: pin charm dependencies in tests (track/0.17)

### DIFF
--- a/charms/kserve-controller/tests/integration/charms_dependencies.py
+++ b/charms/kserve-controller/tests/integration/charms_dependencies.py
@@ -4,18 +4,18 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
-ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
-KNATIVE_OPERATOR = CharmSpec(charm="knative-operator", channel="latest/edge", trust=True)
-KNATIVE_SERVING = CharmSpec(charm="knative-serving", channel="latest/edge", trust=True)
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="1.28/edge", trust=True)
+KNATIVE_OPERATOR = CharmSpec(charm="knative-operator", channel="1.16/edge", trust=True)
+KNATIVE_SERVING = CharmSpec(charm="knative-serving", channel="1.16/edge", trust=True)
 METACONTROLLER_OPERATOR = CharmSpec(
-    charm="metacontroller-operator", channel="latest/edge", trust=True
+    charm="metacontroller-operator", channel="4.11/edge", trust=True
 )
 MINIO = CharmSpec(
     charm="minio",
-    channel="latest/edge",
+    channel="1.10/edge",
     trust=True,
     config={"access-key": "minio", "secret-key": "minio-secret-key"},
 )
-RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="2.0/edge", trust=True)


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track)
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`
- `knative-operator`: `latest/edge` → `1.16/edge`
- `knative-serving`: `latest/edge` → `1.16/edge`
- `metacontroller-operator`: `latest/edge` → `4.11/edge`
- `minio`: `latest/edge` → `1.10/edge`
- `resource-dispatcher`: `latest/edge` → `2.0/edge`

Refs: canonical/bundle-kubeflow#1379
