### PR TITLE
chore: update GPU image

### DIFF
--- a/charms/kserve-controller/src/default-custom-images.json
+++ b/charms/kserve-controller/src/default-custom-images.json
@@ -6,7 +6,7 @@
     "configmap__router": "docker.io/charmedkubeflow/kserve-router:0.17.0-85066a1",
     "configmap__storageInitializer": "docker.io/charmedkubeflow/storage-initializer:0.17.0-07d37fb",
     "serving_runtimes__huggingfaceserver": "docker.io/charmedkubeflow/huggingfaceserver-cpu:0.17.0-c88de31",
-    "serving_runtimes__huggingfaceserver__multinode": "docker.io/charmedkubeflow/huggingfaceserver:0.17.0-e2e8641",
+    "serving_runtimes__huggingfaceserver__multinode": "ghcr.io/canonical/huggingfaceserver:0.17.0-e2e8641-gpu",
     "serving_runtimes__lgbserver": "docker.io/charmedkubeflow/lgbserver:0.17.0-1ddb2d3",
     "serving_runtimes__kserve_mlserver": "docker.io/seldonio/mlserver:1.5.0",
     "serving_runtimes__paddleserver": "docker.io/charmedkubeflow/paddleserver:0.17.0-e671f6f",


### PR DESCRIPTION
This pull request updates the GPU image from Docker Hub to GHCR after the latest tag was pushed there: https://github.com/canonical/kserve-rocks/pkgs/container/huggingfaceserver