### PR TITLE
test: make ambient-mode integration tests non-flaky

### DIFF
--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -7,6 +7,7 @@ import base64
 import json
 import logging
 from pathlib import Path
+from pyexpat import model
 
 import lightkube
 import lightkube.codecs
@@ -57,6 +58,14 @@ from tests.integration.utils import (
     populate_template,
 )
 
+# ambient-mode Istio:
+ISTIO_K8S_APP = "istio-k8s"
+ISTIO_INGRESS_K8S_APP = "istio-ingress-k8s"
+ISTIO_BEACON_K8S_APP = "istio-beacon-k8s"
+ISTIO_INGRESS_ROUTE_ENDPOINT = "istio-ingress-route"
+ISTIO_INGRESS_GATEWAY_ENDPOINT = "gateway-metadata"
+SERVICE_MESH_ENDPOINT = "service-mesh"
+
 # tenacity
 RETRY_FOR_THREE_MINUTES = tenacity.Retrying(
     stop=tenacity.stop_after_delay(60 * 3),
@@ -92,6 +101,32 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
 
     Assert on the unit status before any relations/configurations take place.
     """
+    # deploy Istio's ecosystem:
+    istio_channel = "2/stable"
+    await ops_test.model.deploy(
+        ISTIO_K8S_APP,
+        channel=istio_channel,
+        config={"platform": ""},
+        trust=True,
+    )
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        channel=istio_channel,
+        trust=True,
+    )
+    await ops_test.model.deploy(
+        ISTIO_BEACON_K8S_APP,
+        channel=istio_channel,
+        trust=True,
+        config={"model-on-mesh": False},
+    )
+    await ops_test.model.wait_for_idle(
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=900,
+    )
+
     # build and deploy charm from local source folder
     entity_url = (
         await ops_test.build_charm(".")
@@ -111,13 +146,13 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         trust=True,
     )
 
-    await deploy_and_integrate_service_mesh_charms(
-        APP_NAME,
-        model=ops_test.model,
-        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
-        relate_to_beacon=True,
-        relate_to_ingress_route_endpoint=False,
-        relate_to_ingress_gateway_endpoint=True,
+    await ops_test.model.integrate(
+            f"{ISTIO_INGRESS_K8S_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+            f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        )
+    await ops_test.model.integrate(
+        f"{ISTIO_BEACON_K8S_APP}:{SERVICE_MESH_ENDPOINT}",
+        f"{APP_NAME}:{SERVICE_MESH_ENDPOINT}",
     )
 
     # issuing dummy update_status just to trigger an event

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -114,6 +114,7 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
     await deploy_and_integrate_service_mesh_charms(
         APP_NAME,
         model=ops_test.model,
+        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
         relate_to_beacon=True,
         relate_to_ingress_route_endpoint=False,
         relate_to_ingress_gateway_endpoint=True,

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -92,6 +92,15 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
 
     Assert on the unit status before any relations/configurations take place.
     """
+    await deploy_and_integrate_service_mesh_charms(
+        APP_NAME,
+        model=ops_test.model,
+        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
+        relate_to_beacon=True,
+        relate_to_ingress_route_endpoint=False,
+        relate_to_ingress_gateway_endpoint=True,
+    )
+
     # build and deploy charm from local source folder
     entity_url = (
         await ops_test.build_charm(".")
@@ -109,15 +118,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         config={"deployment-mode": "standard"},
         application_name=APP_NAME,
         trust=True,
-    )
-
-    await deploy_and_integrate_service_mesh_charms(
-        APP_NAME,
-        model=ops_test.model,
-        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
-        relate_to_beacon=True,
-        relate_to_ingress_route_endpoint=False,
-        relate_to_ingress_gateway_endpoint=True,
     )
 
     # issuing dummy update_status just to trigger an event

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -92,15 +92,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
 
     Assert on the unit status before any relations/configurations take place.
     """
-    await deploy_and_integrate_service_mesh_charms(
-        APP_NAME,
-        model=ops_test.model,
-        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
-        relate_to_beacon=True,
-        relate_to_ingress_route_endpoint=False,
-        relate_to_ingress_gateway_endpoint=True,
-    )
-
     # build and deploy charm from local source folder
     entity_url = (
         await ops_test.build_charm(".")
@@ -118,6 +109,15 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         config={"deployment-mode": "standard"},
         application_name=APP_NAME,
         trust=True,
+    )
+
+    await deploy_and_integrate_service_mesh_charms(
+        APP_NAME,
+        model=ops_test.model,
+        channel="dev/edge",  # TODO: restore it, just a temporary channel to make the CI non-flaky
+        relate_to_beacon=True,
+        relate_to_ingress_route_endpoint=False,
+        relate_to_ingress_gateway_endpoint=True,
     )
 
     # issuing dummy update_status just to trigger an event

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -7,7 +7,6 @@ import base64
 import json
 import logging
 from pathlib import Path
-from pyexpat import model
 
 import lightkube
 import lightkube.codecs

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -58,7 +58,9 @@ from tests.integration.utils import (
 
 # ambient-mode Istio:
 ISTIO_K8S_APP = "istio-k8s"
+ISTIO_INGRESS_K8S_APP = "istio-ingress-k8s"
 ISTIO_BEACON_K8S_APP = "istio-beacon-k8s"
+ISTIO_INGRESS_GATEWAY_ENDPOINT = "gateway-metadata"
 SERVICE_MESH_ENDPOINT = "service-mesh"
 
 # tenacity
@@ -105,6 +107,11 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         trust=True,
     )
     await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        channel=istio_channel,
+        trust=True,
+    )
+    await ops_test.model.deploy(
         ISTIO_BEACON_K8S_APP,
         channel=istio_channel,
         trust=True,
@@ -136,6 +143,10 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         trust=True,
     )
 
+    await ops_test.model.integrate(
+        f"{ISTIO_INGRESS_K8S_APP}:{ISTIO_INGRESS_GATEWAY_ENDPOINT}",
+        f"{APP_NAME}:{ISTIO_INGRESS_GATEWAY_ENDPOINT}",
+    )
     await ops_test.model.integrate(
         f"{ISTIO_BEACON_K8S_APP}:{SERVICE_MESH_ENDPOINT}",
         f"{APP_NAME}:{SERVICE_MESH_ENDPOINT}",

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -98,6 +98,11 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
 
     Assert on the unit status before any relations/configurations take place.
     """
+    # NOTE: Chisme utilities for deploying Istio's ecosystem and integrating it with KServe are
+    # not employed because, for unclear reasons, deploying Istio after the tested application, as
+    # done in Chisme, gives sporadic, flaky problems with Beacon often stuck in maintenance status
+    # saying: "Validating waypoint readiness"
+
     # deploy Istio's ecosystem:
     istio_channel = "2/stable"
     await ops_test.model.deploy(

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -19,7 +19,6 @@ from charmed_kubeflow_chisme.testing import (
     assert_metrics_endpoint,
     assert_security_context,
     deploy_and_assert_grafana_agent,
-    deploy_and_integrate_service_mesh_charms,
     get_alert_rules,
     get_pod_names,
 )
@@ -146,9 +145,9 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
     )
 
     await ops_test.model.integrate(
-            f"{ISTIO_INGRESS_K8S_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
-            f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
-        )
+        f"{ISTIO_INGRESS_K8S_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
     await ops_test.model.integrate(
         f"{ISTIO_BEACON_K8S_APP}:{SERVICE_MESH_ENDPOINT}",
         f"{APP_NAME}:{SERVICE_MESH_ENDPOINT}",

--- a/charms/kserve-controller/tests/integration/test_charm_ambient.py
+++ b/charms/kserve-controller/tests/integration/test_charm_ambient.py
@@ -58,10 +58,7 @@ from tests.integration.utils import (
 
 # ambient-mode Istio:
 ISTIO_K8S_APP = "istio-k8s"
-ISTIO_INGRESS_K8S_APP = "istio-ingress-k8s"
 ISTIO_BEACON_K8S_APP = "istio-beacon-k8s"
-ISTIO_INGRESS_ROUTE_ENDPOINT = "istio-ingress-route"
-ISTIO_INGRESS_GATEWAY_ENDPOINT = "gateway-metadata"
 SERVICE_MESH_ENDPOINT = "service-mesh"
 
 # tenacity
@@ -108,11 +105,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         trust=True,
     )
     await ops_test.model.deploy(
-        ISTIO_INGRESS_K8S_APP,
-        channel=istio_channel,
-        trust=True,
-    )
-    await ops_test.model.deploy(
         ISTIO_BEACON_K8S_APP,
         channel=istio_channel,
         trust=True,
@@ -144,10 +136,6 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         trust=True,
     )
 
-    await ops_test.model.integrate(
-        f"{ISTIO_INGRESS_K8S_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
-        f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
-    )
     await ops_test.model.integrate(
         f"{ISTIO_BEACON_K8S_APP}:{SERVICE_MESH_ENDPOINT}",
         f"{APP_NAME}:{SERVICE_MESH_ENDPOINT}",


### PR DESCRIPTION
resolves https://github.com/canonical/kserve-operators/issues/479 by deploying Istio before KServe, unlike Chisme does