### PR TITLE
ci: remove library checks (#458)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,17 +8,6 @@ on:
         required: true
 
 jobs:
-  lib-check:
-    name: Check libraries
-    strategy:
-      matrix:
-        charm:
-        - kserve-controller
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: ./charms/${{ matrix.charm }}
-
   lint:
     name: Lint Code
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This backport was created manually since for some reason the bot [wasn't able to do that programmatically](https://github.com/canonical/kserve-operators/pull/458#issuecomment-4516897865), back then