### PR TITLE
fix: Increase timeout in `test_inference_service_proxy_envs_configuration`

### DIFF
--- a/charms/kserve-controller/tests/integration/test_charm_object_storage.py
+++ b/charms/kserve-controller/tests/integration/test_charm_object_storage.py
@@ -436,7 +436,7 @@ async def test_inference_service_proxy_envs_configuration(
         [APP_NAME],
         status="active",
         raise_on_blocked=False,
-        timeout=60 * 1,
+        timeout=60 * 2,
     )
 
     # Create InferenceService from example file


### PR DESCRIPTION
Small PR to fix the sometimes flaky test `test_inference_service_proxy_envs_configuration` by increasing the Juju wait timeout from 1 to 2 minutes.