### PR TITLE
fix: Add s3-credentials relation to terraform module

### DIFF
--- a/charms/kserve-controller/terraform/outputs.tf
+++ b/charms/kserve-controller/terraform/outputs.tf
@@ -17,6 +17,7 @@ output "requires" {
     logging          = "logging",
     object_storage   = "object-storage",
     require_cmr_mesh = "require-cmr-mesh",
+    s3_credentials   = "s3-credentials",
     secrets          = "secrets",
     service_accounts = "service-accounts",
     service_mesh     = "service-mesh"


### PR DESCRIPTION
This PR adds a missing `s3-credentials` output to the Terraform module.